### PR TITLE
Change fonts to Inter

### DIFF
--- a/blocks/dealer-locator/dealer-locator.css
+++ b/blocks/dealer-locator/dealer-locator.css
@@ -237,7 +237,7 @@ main .section.dealer-locator-container>div {
 
 .dealer-locator .tooltip .tooltiptext {
   visibility: hidden;
-  font-family: Arial, sans-serif;
+  font-family: var(--fallback-ff-default);
   width: 120px;
   background-color: #000;
   font-size: 12px;
@@ -1950,7 +1950,7 @@ main .section.dealer-locator-container>div {
   line-height: 18px;
   padding-left: 4px;
   font-size: 15px;
-  font-family: Arial, sans-serif
+  font-family: var(--fallback-ff-default);
 }
 
 .dealer-locator .sidebar .panel-card .panel-container button .icon {

--- a/blocks/dealer-locator/dealer-locator.js
+++ b/blocks/dealer-locator/dealer-locator.js
@@ -26,7 +26,7 @@ export default async function decorate(block) {
     consolidateFilters: true,
     selectedBrand: 'mack',
     dataSource: datasource,
-    apiKey: GOOGLE_API_KEY,
+    apiKey: GOOGLE_API_KEY || '',
     amenities: ['Appointments Accepted', 'Bilingual Service', 'Driver Lounge', 'Free Pickup and Delivery', 'Hotel Shuttle', 'Internet Service', 'Laundry', 'Showers', 'Telephones', 'Trailer Parking', 'Video Games'],
   };
 

--- a/blocks/dealer-locator/dealer-locator.js
+++ b/blocks/dealer-locator/dealer-locator.js
@@ -19,6 +19,7 @@ export default async function decorate(block) {
   // add the zip code to the input search, if it is present
   const zipCode = hasZipLocation ? escapeHTML(searchParams.get('l')) : null;
   const datasource = block.textContent.trim();
+  if (!GOOGLE_API_KEY) return;
   window.locatorConfig = {
     asist: false,
     showAsistDialog: true,

--- a/blocks/dealer-locator/dealer-locator.js
+++ b/blocks/dealer-locator/dealer-locator.js
@@ -19,7 +19,7 @@ export default async function decorate(block) {
   // add the zip code to the input search, if it is present
   const zipCode = hasZipLocation ? escapeHTML(searchParams.get('l')) : null;
   const datasource = block.textContent.trim();
-  if (!GOOGLE_API_KEY) return;
+
   window.locatorConfig = {
     asist: false,
     showAsistDialog: true,

--- a/blocks/dealer-locator/sidebar-maps.js
+++ b/blocks/dealer-locator/sidebar-maps.js
@@ -2824,7 +2824,7 @@ $.fn.drawPin = function (text, width, height, color) {
     color = '85754d';
   }
 
-  return 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22' + width + '%22%20height%3D%22' + height + '%22%20viewBox%3D%220%200%2038%2038%22%3E%3Cpath%20fill%3D%22%23' + color + '%22%20stroke%3D%22%23ccc%22%20stroke-width%3D%22.5%22%20d%3D%22M34.305%2016.234c0%208.83-15.148%2019.158-15.148%2019.158S3.507%2025.065%203.507%2016.1c0-8.505%206.894-14.304%2015.4-14.304%208.504%200%2015.398%205.933%2015.398%2014.438z%22%2F%3E%3Ctext%20transform%3D%22translate%2819%2018.5%29%22%20fill%3D%22%23fff%22%20style%3D%22font-family%3A%20Arial%2C%20sans-serif%3Bfont-weight%3Abold%3Btext-align%3Acenter%3B%22%20font-size%3D%2212%22%20text-anchor%3D%22middle%22%3E' + text + '%3C%2Ftext%3E%3C%2Fsvg%3E';
+  return 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22' + width + '%22%20height%3D%22' + height + '%22%20viewBox%3D%220%200%2038%2038%22%3E%3Cpath%20fill%3D%22%23' + color + '%22%20stroke%3D%22%23ccc%22%20stroke-width%3D%22.5%22%20d%3D%22M34.305%2016.234c0%208.83-15.148%2019.158-15.148%2019.158S3.507%2025.065%203.507%2016.1c0-8.505%206.894-14.304%2015.4-14.304%208.504%200%2015.398%205.933%2015.398%2014.438z%22%2F%3E%3Ctext%20transform%3D%22translate%2819%2018.5%29%22%20fill%3D%22%23fff%22%20style%3D%22font-family%3A%20Inter%2C%20sans-serif%3Bfont-weight%3Abold%3Btext-align%3Acenter%3B%22%20font-size%3D%2212%22%20text-anchor%3D%22middle%22%3E' + text + '%3C%2Ftext%3E%3C%2Fsvg%3E';
 };
 
 $.fn.handleLocationError = function (browserHasGeolocation, infoWindow, pos) {

--- a/blocks/eloqua-form/forms/buy-mack-request-a-quote.html
+++ b/blocks/eloqua-form/forms/buy-mack-request-a-quote.html
@@ -118,7 +118,7 @@
     -webkit-tap-highlight-color: transparent;
   }
   .elq-form body {
-    font-family: Helvetica Neue, Helvetica, Inter, sans-serif;
+    font-family: Inter, sans-serif;
     font-size: 14px;
     line-height: 1.42857;
     color: #333;

--- a/blocks/eloqua-form/forms/buy-mack-request-a-quote.html
+++ b/blocks/eloqua-form/forms/buy-mack-request-a-quote.html
@@ -118,7 +118,7 @@
     -webkit-tap-highlight-color: transparent;
   }
   .elq-form body {
-    font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+    font-family: Helvetica Neue, Helvetica, Inter, sans-serif;
     font-size: 14px;
     line-height: 1.42857;
     color: #333;

--- a/blocks/eloqua-form/forms/contact-us.html
+++ b/blocks/eloqua-form/forms/contact-us.html
@@ -89,7 +89,7 @@
     font-size:10px;
     -webkit-tap-highlight-color:transparent}
   .elq-form body{
-    font-family:Helvetica Neue,Helvetica,Inter,sans-serif;
+    font-family:Inter,sans-serif;
     font-size:14px;
     line-height:1.42857;
     color:#333;

--- a/blocks/eloqua-form/forms/contact-us.html
+++ b/blocks/eloqua-form/forms/contact-us.html
@@ -89,7 +89,7 @@
     font-size:10px;
     -webkit-tap-highlight-color:transparent}
   .elq-form body{
-    font-family:Helvetica Neue,Helvetica,Arial,sans-serif;
+    font-family:Helvetica Neue,Helvetica,Inter,sans-serif;
     font-size:14px;
     line-height:1.42857;
     color:#333;

--- a/blocks/eloqua-form/forms/electrifi.html
+++ b/blocks/eloqua-form/forms/electrifi.html
@@ -89,7 +89,7 @@
       font-size:10px;
       -webkit-tap-highlight-color:transparent}
     .elq-form body{
-      font-family:Helvetica Neue,Helvetica,Arial,sans-serif;
+      font-family:Helvetica Neue,Helvetica,Inter,sans-serif;
       font-size:14px;
       line-height:1.42857;
       color:#333;

--- a/blocks/eloqua-form/forms/electrifi.html
+++ b/blocks/eloqua-form/forms/electrifi.html
@@ -89,7 +89,7 @@
       font-size:10px;
       -webkit-tap-highlight-color:transparent}
     .elq-form body{
-      font-family:Helvetica Neue,Helvetica,Inter,sans-serif;
+      font-family:Inter,sans-serif;
       font-size:14px;
       line-height:1.42857;
       color:#333;

--- a/blocks/eloqua-form/forms/lr-electric-vehicle-as-a-service.html
+++ b/blocks/eloqua-form/forms/lr-electric-vehicle-as-a-service.html
@@ -118,7 +118,7 @@
     -webkit-tap-highlight-color: transparent;
   }
   .elq-form body {
-    font-family: Helvetica Neue, Helvetica, Inter, sans-serif;
+    font-family: Inter, sans-serif;
     font-size: 14px;
     line-height: 1.42857;
     color: #333;

--- a/blocks/eloqua-form/forms/lr-electric-vehicle-as-a-service.html
+++ b/blocks/eloqua-form/forms/lr-electric-vehicle-as-a-service.html
@@ -118,7 +118,7 @@
     -webkit-tap-highlight-color: transparent;
   }
   .elq-form body {
-    font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+    font-family: Helvetica Neue, Helvetica, Inter, sans-serif;
     font-size: 14px;
     line-height: 1.42857;
     color: #333;

--- a/blocks/eloqua-form/forms/magazine-share.html
+++ b/blocks/eloqua-form/forms/magazine-share.html
@@ -89,7 +89,7 @@
     font-size:10px;
     -webkit-tap-highlight-color:transparent}
   .elq-form body{
-    font-family:Helvetica Neue,Helvetica,Inter,sans-serif;
+    font-family:Inter,sans-serif;
     font-size:14px;
     line-height:1.42857;
     color:#333;

--- a/blocks/eloqua-form/forms/magazine-share.html
+++ b/blocks/eloqua-form/forms/magazine-share.html
@@ -89,7 +89,7 @@
     font-size:10px;
     -webkit-tap-highlight-color:transparent}
   .elq-form body{
-    font-family:Helvetica Neue,Helvetica,Arial,sans-serif;
+    font-family:Helvetica Neue,Helvetica,Inter,sans-serif;
     font-size:14px;
     line-height:1.42857;
     color:#333;

--- a/blocks/eloqua-form/forms/magazine-subscribe.html
+++ b/blocks/eloqua-form/forms/magazine-subscribe.html
@@ -89,7 +89,7 @@
     font-size:10px;
     -webkit-tap-highlight-color:transparent}
   .elq-form body{
-    font-family:Helvetica Neue,Helvetica,Inter,sans-serif;
+    font-family:Inter,sans-serif;
     font-size:14px;
     line-height:1.42857;
     color:#333;

--- a/blocks/eloqua-form/forms/magazine-subscribe.html
+++ b/blocks/eloqua-form/forms/magazine-subscribe.html
@@ -89,7 +89,7 @@
     font-size:10px;
     -webkit-tap-highlight-color:transparent}
   .elq-form body{
-    font-family:Helvetica Neue,Helvetica,Arial,sans-serif;
+    font-family:Helvetica Neue,Helvetica,Inter,sans-serif;
     font-size:14px;
     line-height:1.42857;
     color:#333;

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -12,7 +12,7 @@ import {
 import { getAllElWithChildren } from '../../scripts/scripts.js';
 
 // check if the header has to have a login and/or a search button
-const { SEARCH_DISABLED, LOGIN_DISABLED } = HEADER_CONFIGS;
+const { SEARCH_DISABLED = '', LOGIN_DISABLED = '' } = HEADER_CONFIGS;
 
 const blockClass = 'header';
 

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -2,7 +2,7 @@
 
 /* auto and non-auto block shared styles */
 :root {
-  --hero-header-ff: var(--ff-helvetica-heavy);
+  --hero-header-ff: var(--ff-inter-heavy);
   --hero-text-ff: var(--ff-subheadings-medium);
   --hero-btn-ff: var(--ff-body-bold);
   --hero-text-size: 20px;

--- a/blocks/inventory/inventory.css
+++ b/blocks/inventory/inventory.css
@@ -23,7 +23,7 @@
 }
 
 .inventory.block h1 {
-  font: 60px/60px var(--ff-helvetica-heavy);
+  font: 60px/60px var(--ff-inter-heavy);
   padding: 0 !important;
 }
 

--- a/blocks/magazine-subscribe/magazine-subscribe.js
+++ b/blocks/magazine-subscribe/magazine-subscribe.js
@@ -20,7 +20,7 @@ export default async function decorate(block) {
 
   const iframeLink = createElement('a', {
     classes: 'iframe-link',
-    props: { href },
+    props: { href: href || '#' },
   });
   const iframeForm = buildBlock('iframe', { elems: [iframeLink] });
 

--- a/blocks/magazine-subscribe/magazine-subscribe.js
+++ b/blocks/magazine-subscribe/magazine-subscribe.js
@@ -20,7 +20,7 @@ export default async function decorate(block) {
 
   const iframeLink = createElement('a', {
     classes: 'iframe-link',
-    props: { href: href || '#' },
+    props: { href: href || '' },
   });
   const iframeForm = buildBlock('iframe', { elems: [iframeLink] });
 

--- a/blocks/performance-specifications/performance-specifications.js
+++ b/blocks/performance-specifications/performance-specifications.js
@@ -125,7 +125,7 @@ const updateChart = async (chartContainer, performanceData) => {
   const option = {
     legend: {
       icon: 'circle',
-      fontFamily: 'Helvetica Neue LT Pro 75 Bold',
+      fontFamily: 'Inter 75 Bold',
       top: 'top',
       left: MQ.matches ? 'auto' : '0',
       right: MQ.matches ? '0' : 'auto',

--- a/blocks/search/search-api.js
+++ b/blocks/search/search-api.js
@@ -5,20 +5,32 @@ const isProd = !window.location.host.includes('hlx.page') && !window.location.ho
 const SEARCH_LINK = !isProd ? SEARCH_URL_DEV : SEARCH_URL_PROD;
 
 export async function fetchData(queryObj) {
-  const response = await fetch(
-    SEARCH_LINK,
-    {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        'Content-Length': queryObj.length,
-      },
-      body: JSON.stringify(queryObj),
-    },
-  );
+  try {
+    if (!SEARCH_LINK) {
+      throw new Error('SEARCH_LINK is not defined');
+    }
 
-  return response.json();
+    const response = await fetch(
+      SEARCH_LINK,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'Content-Length': queryObj.length,
+        },
+        body: JSON.stringify(queryObj),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    return response.json();
+  } catch (error) {
+    throw new Error(`Fetch error: ${error.message}`);
+  }
 }
 
 export const searchQuery = (hasFilters) => `

--- a/blocks/v2-dealer-locator/v2-dealer-locator.css
+++ b/blocks/v2-dealer-locator/v2-dealer-locator.css
@@ -239,7 +239,7 @@ main .section.v2-dealer-locator-container>div {
 
 .v2-dealer-locator .tooltip .tooltiptext {
   visibility: hidden;
-  font-family: Arial, sans-serif;
+  font-family: var(--fallback-ff-default);
   width: 120px;
   background-color: #000;
   font-size: 12px;
@@ -1953,7 +1953,7 @@ main .section.v2-dealer-locator-container>div {
   line-height: 18px;
   padding-left: 4px;
   font-size: 15px;
-  font-family: Arial, sans-serif
+  font-family: var(--fallback-ff-default);
 }
 
 .v2-dealer-locator .sidebar .panel-card .panel-container button .icon {

--- a/blocks/v2-dealer-locator/v2-dealer-locator.js
+++ b/blocks/v2-dealer-locator/v2-dealer-locator.js
@@ -85,8 +85,9 @@ export default async function decorate(block) {
 
   // blockConfig.datasource is a required field for the block to work:
   if (!blockConfig.datasource) {
-    // eslint-disable-next-line no-console
     console.error('The block is missing the datasource field in the configuration.');
+  } else if (!GOOGLE_API_KEY) {
+    console.error('The block is missing the %cGOOGLE_API_KEY%c in the %cTOOLS_CONFIGS', 'color: red;', 'color: initial;', 'color: red;');
   } else {
     window.locatorConfig = {
       asist: false,

--- a/blocks/v2-dealer-locator/versions/default/sidebar-maps.js
+++ b/blocks/v2-dealer-locator/versions/default/sidebar-maps.js
@@ -2823,7 +2823,7 @@ $.fn.drawPin = function (text, width, height, color) {
     color = '85754d';
   }
 
-  return 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22' + width + '%22%20height%3D%22' + height + '%22%20viewBox%3D%220%200%2038%2038%22%3E%3Cpath%20fill%3D%22%23' + color + '%22%20stroke%3D%22%23ccc%22%20stroke-width%3D%22.5%22%20d%3D%22M34.305%2016.234c0%208.83-15.148%2019.158-15.148%2019.158S3.507%2025.065%203.507%2016.1c0-8.505%206.894-14.304%2015.4-14.304%208.504%200%2015.398%205.933%2015.398%2014.438z%22%2F%3E%3Ctext%20transform%3D%22translate%2819%2018.5%29%22%20fill%3D%22%23fff%22%20style%3D%22font-family%3A%20Arial%2C%20sans-serif%3Bfont-weight%3Abold%3Btext-align%3Acenter%3B%22%20font-size%3D%2212%22%20text-anchor%3D%22middle%22%3E' + text + '%3C%2Ftext%3E%3C%2Fsvg%3E';
+  return 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22' + width + '%22%20height%3D%22' + height + '%22%20viewBox%3D%220%200%2038%2038%22%3E%3Cpath%20fill%3D%22%23' + color + '%22%20stroke%3D%22%23ccc%22%20stroke-width%3D%22.5%22%20d%3D%22M34.305%2016.234c0%208.83-15.148%2019.158-15.148%2019.158S3.507%2025.065%203.507%2016.1c0-8.505%206.894-14.304%2015.4-14.304%208.504%200%2015.398%205.933%2015.398%2014.438z%22%2F%3E%3Ctext%20transform%3D%22translate%2819%2018.5%29%22%20fill%3D%22%23fff%22%20style%3D%22font-family%3A%20Inter%2C%20sans-serif%3Bfont-weight%3Abold%3Btext-align%3Acenter%3B%22%20font-size%3D%2212%22%20text-anchor%3D%22middle%22%3E' + text + '%3C%2Ftext%3E%3C%2Fsvg%3E';
 };
 
 $.fn.handleLocationError = function (browserHasGeolocation, infoWindow, pos) {

--- a/blocks/v2-dealer-locator/versions/export/sidebar-maps.js
+++ b/blocks/v2-dealer-locator/versions/export/sidebar-maps.js
@@ -2611,7 +2611,7 @@ $.fn.drawPin = function (text, width, height, color) {
     color = '85754d';
   }
 
-  return 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22' + width + '%22%20height%3D%22' + height + '%22%20viewBox%3D%220%200%2038%2038%22%3E%3Cpath%20fill%3D%22%23' + color + '%22%20stroke%3D%22%23ccc%22%20stroke-width%3D%22.5%22%20d%3D%22M34.305%2016.234c0%208.83-15.148%2019.158-15.148%2019.158S3.507%2025.065%203.507%2016.1c0-8.505%206.894-14.304%2015.4-14.304%208.504%200%2015.398%205.933%2015.398%2014.438z%22%2F%3E%3Ctext%20transform%3D%22translate%2819%2018.5%29%22%20fill%3D%22%23fff%22%20style%3D%22font-family%3A%20Arial%2C%20sans-serif%3Bfont-weight%3Abold%3Btext-align%3Acenter%3B%22%20font-size%3D%2212%22%20text-anchor%3D%22middle%22%3E' + text + '%3C%2Ftext%3E%3C%2Fsvg%3E';
+  return 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22' + width + '%22%20height%3D%22' + height + '%22%20viewBox%3D%220%200%2038%2038%22%3E%3Cpath%20fill%3D%22%23' + color + '%22%20stroke%3D%22%23ccc%22%20stroke-width%3D%22.5%22%20d%3D%22M34.305%2016.234c0%208.83-15.148%2019.158-15.148%2019.158S3.507%2025.065%203.507%2016.1c0-8.505%206.894-14.304%2015.4-14.304%208.504%200%2015.398%205.933%2015.398%2014.438z%22%2F%3E%3Ctext%20transform%3D%22translate%2819%2018.5%29%22%20fill%3D%22%23fff%22%20style%3D%22font-family%3A%20Inter%2C%20sans-serif%3Bfont-weight%3Abold%3Btext-align%3Acenter%3B%22%20font-size%3D%2212%22%20text-anchor%3D%22middle%22%3E' + text + '%3C%2Ftext%3E%3C%2Fsvg%3E';
 };
 
 $.fn.handleLocationError = function (browserHasGeolocation, infoWindow, pos) {

--- a/constants.json
+++ b/constants.json
@@ -18,7 +18,7 @@
           },
           {
               "name": "v1SectionClasses",
-              "value": "[\"background\",\"background-top\",\"bg-paper\",\"bg-white-paper\",\"dark-background\",\"center\",\"flex-center\",\"font-l\",\"font-m\",\"font-s\",\"font-xl\",\"font-xxl\",\"font-xs\",\"font-xxs\",\"helvetica-55\",\"helvetica-65\",\"helvetica-75\",\"helvetica-56\",\"helvetica-66\",\"helvetica-76\",\"gap\",\"highlight\",\"line-separator\",\"magazine-listing-content\",\"no-first-line\",\"padding-0\",\"padding-16\",\"padding-32\",\"section-width\",\"text-white\",\"text-black\",\"responsive-title\",\"title-line\",\"title-margin-bottom-0\",\"title-white\",\"wrapper-margin-top-0\"]"
+              "value": "[\"background\",\"background-top\",\"bg-paper\",\"bg-white-paper\",\"dark-background\",\"center\",\"flex-center\",\"font-l\",\"font-m\",\"font-s\",\"font-xl\",\"font-xxl\",\"font-xs\",\"font-xxs\",\"font-55\",\"font-65\",\"font-75\",\"font-56\",\"font-66\",\"font-76\",\"gap\",\"highlight\",\"line-separator\",\"magazine-listing-content\",\"no-first-line\",\"padding-0\",\"padding-16\",\"padding-32\",\"section-width\",\"text-white\",\"text-black\",\"responsive-title\",\"title-line\",\"title-margin-bottom-0\",\"title-white\",\"wrapper-margin-top-0\"]"
           },
           {
               "name": "v2SectionClasses",

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -335,7 +335,7 @@ async function getConstantValues() {
  * @returns {Object} An parsed object with those values and keys
  */
 export const extractObjectFromArray = (data) => {
-  if (!data || !Array.isArray(data)) return {};
+  if (!Array.isArray(data)) return {};
   const obj = {};
   for (const item of data) {
     try {
@@ -458,7 +458,7 @@ export const getJsonFromUrl = async (route) => {
  *                     original input.
  */
 export const formatStringToArray = (inputString) => {
-  if (!inputString || typeof inputString !== 'string') return [];
+  if (typeof inputString !== 'string') return [];
   // eslint-disable-next-line no-useless-escape
   const cleanedString = inputString.replace(/[\[\]\\'"]+/g, '');
   return cleanedString.split(',')

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -335,6 +335,7 @@ async function getConstantValues() {
  * @returns {Object} An parsed object with those values and keys
  */
 export const extractObjectFromArray = (data) => {
+  if (!data) return {};
   const obj = {};
   for (const item of data) {
     try {

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -335,7 +335,7 @@ async function getConstantValues() {
  * @returns {Object} An parsed object with those values and keys
  */
 export const extractObjectFromArray = (data) => {
-  if (!data) return {};
+  if (!data || !Array.isArray(data)) return {};
   const obj = {};
   for (const item of data) {
     try {
@@ -458,6 +458,7 @@ export const getJsonFromUrl = async (route) => {
  *                     original input.
  */
 export const formatStringToArray = (inputString) => {
+  if (!inputString || typeof inputString !== 'string') return [];
   // eslint-disable-next-line no-useless-escape
   const cleanedString = inputString.replace(/[\[\]\\'"]+/g, '');
   return cleanedString.split(',')

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -21,11 +21,6 @@ const {
   LINKEDIN_PARTNER_ID = false,
 } = COOKIE_CONFIGS;
 
-const parsedData = JSON.parse(ACC_ENG_TRACKING);
-const splitData = extractObjectFromArray(parsedData);
-
-const { piAId, piCId, piHostname } = splitData;
-
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
 
@@ -47,7 +42,7 @@ if (isTargetingAllowed()) {
 // add more delayed functionality here
 
 // Prevent the cookie banner from loading when running in library
-if (!window.location.pathname.includes('srcdoc')
+if (DATA_DOMAIN_SCRIPT && !window.location.pathname.includes('srcdoc')
   && !devHosts.some((url) => window.location.host.includes(url))) {
   loadScript('https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', {
     type: 'text/javascript',
@@ -102,6 +97,10 @@ async function loadHotjar() {
 
 // Account Engagement Tracking Code
 async function loadAccountEngagementTracking() {
+  const {
+    piAId = null, piCId = null, piHostname = null,
+  } = extractObjectFromArray(JSON.parse(ACC_ENG_TRACKING));
+  if (!piAId || !piCId || !piHostname) return;
   const body = document.querySelector('body');
   const script = document.createElement('script');
   script.type = 'text/javascript';

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -751,6 +751,10 @@ const moveClassToHtmlEl = (className, elementSelector = 'main') => {
 moveClassToHtmlEl('redesign-v2');
 moveClassToHtmlEl('truck-configurator');
 
+function hasConfigURLs() {
+  return TRUCK_CONFIGURATOR_URLS && TRUCK_CONFIGURATOR_URLS.JS && TRUCK_CONFIGURATOR_URLS.CSS;
+}
+
 if (document.documentElement.classList.contains('truck-configurator')) {
   const allowedCountries = getMetadata('allowed-countries');
   const errorPageUrl = getMetadata('redirect-url');
@@ -761,30 +765,32 @@ if (document.documentElement.classList.contains('truck-configurator')) {
   main.innerHTML = '';
   main.append(container);
 
-  const jsUrls = formatStringToArray(TRUCK_CONFIGURATOR_URLS.JS);
-  const cssUrls = formatStringToArray(TRUCK_CONFIGURATOR_URLS.CSS);
+  if (hasConfigURLs()) {
+    const { JS, CSS } = TRUCK_CONFIGURATOR_URLS;
+    const jsUrls = formatStringToArray(JS);
+    const cssUrls = formatStringToArray(CSS);
 
-  jsUrls.forEach((url) => {
-    loadScript(url, { type: 'text/javascript', charset: 'UTF-8', defer: 'defer' });
-  });
+    jsUrls.forEach((url) => {
+      loadScript(url, { type: 'text/javascript', charset: 'UTF-8', defer: 'defer' });
+    });
 
-  cssUrls.forEach((url) => {
-    loadCSS(url);
-  });
+    cssUrls.forEach((url) => {
+      loadCSS(url);
+    });
 
-  window.addEventListener('reactRouterChange', (e) => {
-    const newLocation = e.detail;
+    window.addEventListener('reactRouterChange', (e) => {
+      const newLocation = e.detail;
 
-    // eslint-disable-next-line no-console
-    console.info('[truck-configurator]: React Router location changed:', newLocation);
+      console.info('[truck-configurator]: React Router location changed:', newLocation);
 
-    if (newLocation.pathname && newLocation.pathname !== '/' && disableHeader) {
-      document.documentElement.classList.add('truck-configurator--detail-page');
-    }
-    if (newLocation.pathname && (newLocation.pathname === '/' || newLocation.pathname === '')) {
-      document.documentElement.classList.remove('truck-configurator--detail-page');
-    }
-  });
+      if (newLocation.pathname && newLocation.pathname !== '/' && disableHeader) {
+        document.documentElement.classList.add('truck-configurator--detail-page');
+      }
+      if (newLocation.pathname && (newLocation.pathname === '/' || newLocation.pathname === '')) {
+        document.documentElement.classList.remove('truck-configurator--detail-page');
+      }
+    });
+  }
 }
 
 if (getMetadata('truck-configurator-page')) {

--- a/scripts/validate-countries.js
+++ b/scripts/validate-countries.js
@@ -6,6 +6,10 @@ const languageCode = 'en';
 export const splitString = (str) => str.split(',').map((item) => item.trim());
 
 export const getUserCountryName = async (lat, lng) => {
+  if (!GOOGLE_API_KEY) {
+    console.error('Google API key is missing');
+    return null;
+  }
   const apiUrl = `https://maps.googleapis.com/maps/api/geocode/json?latlng=${lat},${lng}&language=${languageCode}&key=${GOOGLE_API_KEY}`;
 
   const response = await getJsonFromUrl(apiUrl);

--- a/scripts/validate-elements.js
+++ b/scripts/validate-elements.js
@@ -9,10 +9,10 @@ import showSnackbar from '../common/snackbar/snackbar.js';
 loadCSS(`${window.hlx.codeBasePath}/common/snackbar/snackbar.css`);
 
 const {
-  v1SectionClasses,
-  v2SectionClasses,
-  v1AllowedBlocks,
-  v2AllowedBlocks,
+  v1SectionClasses = '',
+  v2SectionClasses = '',
+  v1AllowedBlocks = '',
+  v2AllowedBlocks = '',
 } = TOOLS_CONFIGS;
 
 const formattedV1SectionClasses = formatStringToArray(v1SectionClasses);

--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -86,14 +86,14 @@
 
 /* Alternate Fonts */
 @font-face {
-  font-family: 'Arial Regular Text Fallback';
-  src: local(arial);
+  font-family: 'Inter Regular Text Fallback';
+  src: local(inter);
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Arial Bold Headline Fallback';
-  src: local(arial);
+  font-family: 'Inter Bold Headline Fallback';
+  src: local(inter);
   font-weight: bold;
   font-display: swap;
 }

--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -24,46 +24,54 @@
 
 /* Subheads, Body Copy, & Legal Copy */
 @font-face {
-  font-family: 'Helvetica Neue LT Pro 55 Roman';
-  src: url('../fonts/HelveticaNeueLTPro-55Roman.otf') format('opentype');
+  font-family: 'Inter 55 Regular';
+  src: url('https://fonts.googleapis.com/css2?family=Inter:wght@400&display=swap') format('woff2');
+  font-weight: 400;
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Helvetica Neue LT Pro 65 Medium';
-  src: url('../fonts/HelveticaNeueLTPro-65Md.otf') format('opentype');
+  font-family: 'Inter 65 Medium';
+  src: url('https://fonts.googleapis.com/css2?family=Inter:wght@500&display=swap') format('woff2');
+  font-weight: 500;
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Helvetica Neue LT Pro 75 Bold';
-  src: url('../fonts/HelveticaNeueLTPro-75Bd.otf') format('opentype');
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Helvetica Neue LT Pro 56 Roman Italic';
-  src: url('../fonts/HelveticaNeueLTPro-56It.otf') format('opentype');
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Helvetica Neue LT Pro 66 Medium Italic';
-  src: url('../fonts/HelveticaNeueLTPro-66MdIt.otf') format('opentype');
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Helvetica Neue LT Pro 76 Bold Italic';
-  src: url('../fonts/HelveticaNeueLTPro-76BdIt.otf') format('opentype');
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Helvetica Neue 85 Heavy';
-  src: url('../fonts/helveticaneueltpro-hv.woff') format('woff');
+  font-family: 'Inter 75 Bold';
+  src: url('https://fonts.googleapis.com/css2?family=Inter:wght@700&display=swap') format('woff2');
   font-weight: 700;
-  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Inter 56 Regular Italic';
+  src: url('https://fonts.googleapis.com/css2?family=Inter:wght@400&style=italic&display=swap') format('woff2');
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Inter 66 Medium Italic';
+  src: url('https://fonts.googleapis.com/css2?family=Inter:wght@500&style=italic&display=swap') format('woff2');
+  font-weight: 500;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Inter 76 Bold Italic';
+  src: url('https://fonts.googleapis.com/css2?family=Inter:wght@700&style=italic&display=swap') format('woff2');
+  font-weight: 700;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Inter 85 Heavy';
+  src: url('https://fonts.googleapis.com/css2?family=Inter:wght@800&display=swap') format('woff2');
+  font-weight: 800;
   font-display: swap;
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -8,7 +8,7 @@
   font-family: "fontawesome Fallback";
   font-style: normal;
   font-weight: 400;
-  src: local("Arial");
+  src: local("Inter");
   ascent-override: 93.75%;
   descent-override: 6.25%;
   line-gap-override: 0.00%;
@@ -92,9 +92,10 @@
   /* Font family */
 
   /* Alternate fonts */
-  --fallback-ff-texts: "Arial Regular Text Fallback", helvetica, sans-serif;
-  --fallback-ff-headlines: "Arial Bold Headline Fallback", helvetica, sans-serif;
-  --fallback-ff-accents: "Arial Regular Text Fallback", helvetica, sans-serif;
+  --fallback-ff-default: inter, sans-serif;
+  --fallback-ff-texts: "Inter Regular Text Fallback", helvetica, sans-serif;
+  --fallback-ff-headlines: "Inter Bold Headline Fallback", helvetica, sans-serif;
+  --fallback-ff-accents: "Inter Regular Text Fallback", helvetica, sans-serif;
 
   /* Headlines */
   --ff-headline-medium: "GT America Extended Medium", var(--fallback-ff-headlines);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -93,18 +93,18 @@
 
   /* Alternate fonts */
   --fallback-ff-default: inter, sans-serif;
-  --fallback-ff-texts: "Inter Regular Text Fallback", helvetica, sans-serif;
-  --fallback-ff-headlines: "Inter Bold Headline Fallback", helvetica, sans-serif;
-  --fallback-ff-accents: "Inter Regular Text Fallback", helvetica, sans-serif;
+  --fallback-ff-texts: "Inter Regular Text Fallback", sans-serif;
+  --fallback-ff-headlines: "Inter Bold Headline Fallback", sans-serif;
+  --fallback-ff-accents: "Inter Regular Text Fallback", sans-serif;
 
   /* Headlines */
   --ff-headline-medium: "GT America Extended Medium", var(--fallback-ff-headlines);
   --ff-headline-compressed: "GT America Compressed Regular", var(--fallback-ff-headlines);
-  --ff-subheadings-medium: "Helvetica Neue LT Pro 65 Medium", var(--fallback-ff-texts);
+  --ff-subheadings-medium: "Inter 65 Medium", var(--fallback-ff-texts);
 
   /* Body */
-  --ff-body: "Helvetica Neue LT Pro 55 Roman", var(--fallback-ff-texts);
-  --ff-body-bold: "Helvetica Neue LT Pro 75 Bold", var(--fallback-ff-texts);
+  --ff-body: "Inter 55 Regular", var(--fallback-ff-texts);
+  --ff-body-bold: "Inter 75 Bold", var(--fallback-ff-texts);
   --ff-testimonial: "GT America Extended Regular", var(--fallback-ff-accents);
   --ff-accents: "GT America Mono Regular", var(--fallback-ff-accents);
 
@@ -123,15 +123,15 @@
   --headline-2-line-height: 115%;
   --headline-2-letter-spacing: -2%;
 
-  /* Helvetica Neue LT Pro, 65 Medium, 32px, 115% / 28px, 115% */
+  /* Inter, 65 Medium, 32px, 115% / 28px, 115% */
   --headline-3-font-size: 2.8rem; /* 28px */
   --headline-3-line-height: 115%;
 
-  /* Helvetica Neue LT Pro, 65 Medium, 24px, 140%  */
+  /* Inter, 65 Medium, 24px, 140%  */
   --headline-4-font-size: 2.4rem; /* 24px */
   --headline-4-line-height: 140%;
 
-  /* Helvetica Neue LT Pro, 65 Medium, 18px, 140%  */
+  /* Inter, 65 Medium, 18px, 140%  */
   --headline-5-font-size: 1.8rem; /* 18px */
   --headline-5-line-height: 140%;
 
@@ -148,10 +148,10 @@
   OLD CSS VARIABLES
   */
 
-  --ff-helvetica-heavy: "Helvetica Neue 85 Heavy", var(--fallback-ff-texts);
-  --ff-helvetica-roman-italic: "Helvetica Neue LT Pro 56 Roman Italic", var(--fallback-ff-texts);
-  --ff-helvetica-medium-italic: "Helvetica Neue LT Pro 66 Medium Italic", var(--fallback-ff-texts);
-  --ff-helvetica-bold-italic: "Helvetica Neue LT Pro 76 Bold Italic", var(--fallback-ff-texts);
+  --ff-inter-heavy: "Inter 85 Heavy", var(--fallback-ff-texts);
+  --ff-inter-roman-italic: "Inter 56 Regular Italic", var(--fallback-ff-texts);
+  --ff-inter-medium-italic: "Inter 66 Medium Italic", var(--fallback-ff-texts);
+  --ff-inter-bold-italic: "Inter 76 Bold Italic", var(--fallback-ff-texts);
 
   /* Accent elements */
   --ff-accents-medium: "GT America Mono Medium", var(--fallback-ff-accents);
@@ -816,32 +816,32 @@ main .section.section-width {
   }
 }
 
-main .section.helvetica-55 {
+main .section.font-55 {
   font-family: var(--ff-body);
 }
 
-main .section.helvetica-65 {
+main .section.font-65 {
   font-family: var(--ff-subheadings-medium);
 }
 
-main .section.helvetica-75 {
+main .section.font-75 {
   font-family: var(--ff-body-bold);
 }
 
-main .section.helvetica-56 {
-  font-family: var(--ff-helvetica-roman-italic);
+main .section.font-56 {
+  font-family: var(--ff-inter-roman-italic);
 }
 
-main .section.helvetica-66 {
-  font-family: var(--ff-helvetica-medium-italic);
+main .section.font-66 {
+  font-family: var(--ff-inter-medium-italic);
 }
 
-main .section.helvetica-76 {
-  font-family: var(--ff-helvetica-bold-italic);
+main .section.font-76 {
+  font-family: var(--ff-inter-bold-italic);
 }
 
 main .section.responsive-title h1 {
-  font-family: var(--ff-helvetica-heavy);
+  font-family: var(--ff-inter-heavy);
   font-size: var(--heading-2-mobile-size-l);
 }
 
@@ -871,13 +871,13 @@ main .section.responsive-title h1 {
   /* GT America, Extended Medium, 32px, 115%, -2% / 28px, 115%, -2% */
   --headline-2-font-size: 1.75rem; /* 28px */
 
-  /* Helvetica Neue LT Pro, 65 Medium, 32px, 115% / 28px, 115% */
+  /* Inter, 65 Medium, 32px, 115% / 28px, 115% */
   --headline-3-font-size: 1.75rem; /* 28px */
 
-  /* Helvetica Neue LT Pro, 65 Medium, 24px, 140%  */
+  /* Inter, 65 Medium, 24px, 140%  */
   --headline-4-font-size: 1.5rem; /* 24px */
 
-  /* Helvetica Neue LT Pro, 65 Medium, 18px, 140%  */
+  /* Inter, 65 Medium, 18px, 140%  */
   --headline-5-font-size: 1.125rem; /* 18px */
 
   /* Body font sizes */
@@ -891,11 +891,11 @@ main .section.responsive-title h1 {
   /* stylelint-disable-next-line number-max-precision */
   --body-font-size-xxs: 0.8125rem; /* 13px */
 
-  /* Helvetica Neue LT Pro, 55 Roman / Helvetica Neue LT Pro, 75 Bold, 16px, 150%  */
+  /* Inter, 55 Regular / Inter, 75 Bold, 16px, 150%  */
   --body-1-font-size: 1rem; /* 16px */
   --body-1-line-height: 150%;
 
-  /* Helvetica Neue LT Pro, 55 Roman / Helvetica Neue LT Pro, 75 Bold, 13px, 160%  */
+  /* Inter, 55 Regular / Inter, 75 Bold, 13px, 160%  */
   /* stylelint-disable-next-line number-max-precision */
   --body-2-font-size: 0.8125rem; /* 13px */
   --body-2-line-height: 160%;
@@ -908,15 +908,15 @@ main .section.responsive-title h1 {
   --accent-2-font-size: 0.875rem; /* 14px */
   --accent-2-line-height: 120%;
 
-  /* Helvetica Neue LT Pro, 75 Bold, 14px, 16px */
+  /* Inter, 75 Bold, 14px, 16px */
   --label-font-size: 0.875rem; /* 14px */
   --label-line-height: 16px;
 
-  /* Helvetica Neue LT Pro, 75 Bold, 14px, 16px */
+  /* Inter, 75 Bold, 14px, 16px */
   --label-font-size-small: 0.75rem; /* 12px */
   --label-line-height-small: 16px;
 
-  /* Helvetica Neue LT Pro, 55 Roman, 14px, 18px */
+  /* Inter, 55 Roman, 14px, 18px */
   --button-font-size: 0.875rem; /* 14px */
   --button-line-height: 18px;
 


### PR DESCRIPTION
# Update

This update swaps _Arial_ and _Helvetica_ fonts to _Inter_. 

Some `constants.json` updates must be made across all export markets to mimic this update because all classes called, e.g. `helvetica-55` and similar ones now will be called `font-55` and so on.

If there is a need to change the font linked to that CSS class again, then no more content work will be needed.

### Note

No worries about the branch name, it's just I forgot to work on a new one 😅

Fix #66

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/
- After: https://36-failsafe-for-constants-config--vg-macktrucks-com--volvogroup.aem.page/
