### PR TITLE
Change fonts to Inter #66

### DIFF
--- a/blocks/dealer-locator/dealer-locator.css
+++ b/blocks/dealer-locator/dealer-locator.css
@@ -237,7 +237,7 @@ main .section.dealer-locator-container>div {
 
 .dealer-locator .tooltip .tooltiptext {
   visibility: hidden;
-  font-family: Arial, sans-serif;
+  font-family: var(--fallback-ff-default);
   width: 120px;
   background-color: #000;
   font-size: 12px;
@@ -1950,7 +1950,7 @@ main .section.dealer-locator-container>div {
   line-height: 18px;
   padding-left: 4px;
   font-size: 15px;
-  font-family: Arial, sans-serif
+  font-family: var(--fallback-ff-default);
 }
 
 .dealer-locator .sidebar .panel-card .panel-container button .icon {

--- a/blocks/dealer-locator/sidebar-maps.js
+++ b/blocks/dealer-locator/sidebar-maps.js
@@ -2824,7 +2824,7 @@ $.fn.drawPin = function (text, width, height, color) {
     color = '85754d';
   }
 
-  return 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22' + width + '%22%20height%3D%22' + height + '%22%20viewBox%3D%220%200%2038%2038%22%3E%3Cpath%20fill%3D%22%23' + color + '%22%20stroke%3D%22%23ccc%22%20stroke-width%3D%22.5%22%20d%3D%22M34.305%2016.234c0%208.83-15.148%2019.158-15.148%2019.158S3.507%2025.065%203.507%2016.1c0-8.505%206.894-14.304%2015.4-14.304%208.504%200%2015.398%205.933%2015.398%2014.438z%22%2F%3E%3Ctext%20transform%3D%22translate%2819%2018.5%29%22%20fill%3D%22%23fff%22%20style%3D%22font-family%3A%20Arial%2C%20sans-serif%3Bfont-weight%3Abold%3Btext-align%3Acenter%3B%22%20font-size%3D%2212%22%20text-anchor%3D%22middle%22%3E' + text + '%3C%2Ftext%3E%3C%2Fsvg%3E';
+  return 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22' + width + '%22%20height%3D%22' + height + '%22%20viewBox%3D%220%200%2038%2038%22%3E%3Cpath%20fill%3D%22%23' + color + '%22%20stroke%3D%22%23ccc%22%20stroke-width%3D%22.5%22%20d%3D%22M34.305%2016.234c0%208.83-15.148%2019.158-15.148%2019.158S3.507%2025.065%203.507%2016.1c0-8.505%206.894-14.304%2015.4-14.304%208.504%200%2015.398%205.933%2015.398%2014.438z%22%2F%3E%3Ctext%20transform%3D%22translate%2819%2018.5%29%22%20fill%3D%22%23fff%22%20style%3D%22font-family%3A%20Inter%2C%20sans-serif%3Bfont-weight%3Abold%3Btext-align%3Acenter%3B%22%20font-size%3D%2212%22%20text-anchor%3D%22middle%22%3E' + text + '%3C%2Ftext%3E%3C%2Fsvg%3E';
 };
 
 $.fn.handleLocationError = function (browserHasGeolocation, infoWindow, pos) {

--- a/blocks/eloqua-form/forms/buy-mack-request-a-quote.html
+++ b/blocks/eloqua-form/forms/buy-mack-request-a-quote.html
@@ -118,7 +118,7 @@
     -webkit-tap-highlight-color: transparent;
   }
   .elq-form body {
-    font-family: Inter, sans-serif;
+    font-family: var(--fallback-ff-default);
     font-size: 14px;
     line-height: 1.42857;
     color: #333;

--- a/blocks/eloqua-form/forms/buy-mack-request-a-quote.html
+++ b/blocks/eloqua-form/forms/buy-mack-request-a-quote.html
@@ -118,7 +118,7 @@
     -webkit-tap-highlight-color: transparent;
   }
   .elq-form body {
-    font-family: Helvetica Neue, Helvetica, Inter, sans-serif;
+    font-family: Inter, sans-serif;
     font-size: 14px;
     line-height: 1.42857;
     color: #333;

--- a/blocks/eloqua-form/forms/buy-mack-request-a-quote.html
+++ b/blocks/eloqua-form/forms/buy-mack-request-a-quote.html
@@ -118,7 +118,7 @@
     -webkit-tap-highlight-color: transparent;
   }
   .elq-form body {
-    font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+    font-family: Helvetica Neue, Helvetica, Inter, sans-serif;
     font-size: 14px;
     line-height: 1.42857;
     color: #333;

--- a/blocks/eloqua-form/forms/contact-us.html
+++ b/blocks/eloqua-form/forms/contact-us.html
@@ -89,7 +89,7 @@
     font-size:10px;
     -webkit-tap-highlight-color:transparent}
   .elq-form body{
-    font-family:Inter,sans-serif;
+    font-family: var(--fallback-ff-default);
     font-size:14px;
     line-height:1.42857;
     color:#333;

--- a/blocks/eloqua-form/forms/contact-us.html
+++ b/blocks/eloqua-form/forms/contact-us.html
@@ -89,7 +89,7 @@
     font-size:10px;
     -webkit-tap-highlight-color:transparent}
   .elq-form body{
-    font-family:Helvetica Neue,Helvetica,Inter,sans-serif;
+    font-family:Inter,sans-serif;
     font-size:14px;
     line-height:1.42857;
     color:#333;

--- a/blocks/eloqua-form/forms/contact-us.html
+++ b/blocks/eloqua-form/forms/contact-us.html
@@ -89,7 +89,7 @@
     font-size:10px;
     -webkit-tap-highlight-color:transparent}
   .elq-form body{
-    font-family:Helvetica Neue,Helvetica,Arial,sans-serif;
+    font-family:Helvetica Neue,Helvetica,Inter,sans-serif;
     font-size:14px;
     line-height:1.42857;
     color:#333;

--- a/blocks/eloqua-form/forms/electrifi.html
+++ b/blocks/eloqua-form/forms/electrifi.html
@@ -89,7 +89,7 @@
       font-size:10px;
       -webkit-tap-highlight-color:transparent}
     .elq-form body{
-      font-family:Helvetica Neue,Helvetica,Arial,sans-serif;
+      font-family:Helvetica Neue,Helvetica,Inter,sans-serif;
       font-size:14px;
       line-height:1.42857;
       color:#333;

--- a/blocks/eloqua-form/forms/electrifi.html
+++ b/blocks/eloqua-form/forms/electrifi.html
@@ -89,7 +89,7 @@
       font-size:10px;
       -webkit-tap-highlight-color:transparent}
     .elq-form body{
-      font-family:Inter,sans-serif;
+      font-family: var(--fallback-ff-default);
       font-size:14px;
       line-height:1.42857;
       color:#333;

--- a/blocks/eloqua-form/forms/electrifi.html
+++ b/blocks/eloqua-form/forms/electrifi.html
@@ -89,7 +89,7 @@
       font-size:10px;
       -webkit-tap-highlight-color:transparent}
     .elq-form body{
-      font-family:Helvetica Neue,Helvetica,Inter,sans-serif;
+      font-family:Inter,sans-serif;
       font-size:14px;
       line-height:1.42857;
       color:#333;

--- a/blocks/eloqua-form/forms/lr-electric-vehicle-as-a-service.html
+++ b/blocks/eloqua-form/forms/lr-electric-vehicle-as-a-service.html
@@ -118,7 +118,7 @@
     -webkit-tap-highlight-color: transparent;
   }
   .elq-form body {
-    font-family: Inter, sans-serif;
+    font-family: var(--fallback-ff-default);
     font-size: 14px;
     line-height: 1.42857;
     color: #333;

--- a/blocks/eloqua-form/forms/lr-electric-vehicle-as-a-service.html
+++ b/blocks/eloqua-form/forms/lr-electric-vehicle-as-a-service.html
@@ -118,7 +118,7 @@
     -webkit-tap-highlight-color: transparent;
   }
   .elq-form body {
-    font-family: Helvetica Neue, Helvetica, Inter, sans-serif;
+    font-family: Inter, sans-serif;
     font-size: 14px;
     line-height: 1.42857;
     color: #333;

--- a/blocks/eloqua-form/forms/lr-electric-vehicle-as-a-service.html
+++ b/blocks/eloqua-form/forms/lr-electric-vehicle-as-a-service.html
@@ -118,7 +118,7 @@
     -webkit-tap-highlight-color: transparent;
   }
   .elq-form body {
-    font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+    font-family: Helvetica Neue, Helvetica, Inter, sans-serif;
     font-size: 14px;
     line-height: 1.42857;
     color: #333;

--- a/blocks/eloqua-form/forms/magazine-share.html
+++ b/blocks/eloqua-form/forms/magazine-share.html
@@ -89,7 +89,7 @@
     font-size:10px;
     -webkit-tap-highlight-color:transparent}
   .elq-form body{
-    font-family:Inter,sans-serif;
+    font-family: var(--fallback-ff-default);
     font-size:14px;
     line-height:1.42857;
     color:#333;

--- a/blocks/eloqua-form/forms/magazine-share.html
+++ b/blocks/eloqua-form/forms/magazine-share.html
@@ -89,7 +89,7 @@
     font-size:10px;
     -webkit-tap-highlight-color:transparent}
   .elq-form body{
-    font-family:Helvetica Neue,Helvetica,Inter,sans-serif;
+    font-family:Inter,sans-serif;
     font-size:14px;
     line-height:1.42857;
     color:#333;

--- a/blocks/eloqua-form/forms/magazine-share.html
+++ b/blocks/eloqua-form/forms/magazine-share.html
@@ -89,7 +89,7 @@
     font-size:10px;
     -webkit-tap-highlight-color:transparent}
   .elq-form body{
-    font-family:Helvetica Neue,Helvetica,Arial,sans-serif;
+    font-family:Helvetica Neue,Helvetica,Inter,sans-serif;
     font-size:14px;
     line-height:1.42857;
     color:#333;

--- a/blocks/eloqua-form/forms/magazine-subscribe.html
+++ b/blocks/eloqua-form/forms/magazine-subscribe.html
@@ -89,7 +89,7 @@
     font-size:10px;
     -webkit-tap-highlight-color:transparent}
   .elq-form body{
-    font-family:Inter,sans-serif;
+    font-family: var(--fallback-ff-default);
     font-size:14px;
     line-height:1.42857;
     color:#333;

--- a/blocks/eloqua-form/forms/magazine-subscribe.html
+++ b/blocks/eloqua-form/forms/magazine-subscribe.html
@@ -89,7 +89,7 @@
     font-size:10px;
     -webkit-tap-highlight-color:transparent}
   .elq-form body{
-    font-family:Helvetica Neue,Helvetica,Inter,sans-serif;
+    font-family:Inter,sans-serif;
     font-size:14px;
     line-height:1.42857;
     color:#333;

--- a/blocks/eloqua-form/forms/magazine-subscribe.html
+++ b/blocks/eloqua-form/forms/magazine-subscribe.html
@@ -89,7 +89,7 @@
     font-size:10px;
     -webkit-tap-highlight-color:transparent}
   .elq-form body{
-    font-family:Helvetica Neue,Helvetica,Arial,sans-serif;
+    font-family:Helvetica Neue,Helvetica,Inter,sans-serif;
     font-size:14px;
     line-height:1.42857;
     color:#333;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -236,6 +236,7 @@ a.header__link {
   background: inherit;
   border: none;
   justify-content: center;
+  font-family: var(--ff-body);
 }
 
 .header__link.header__action-link {

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -2,7 +2,7 @@
 
 /* auto and non-auto block shared styles */
 :root {
-  --hero-header-ff: var(--ff-helvetica-heavy);
+  --hero-header-ff: var(--ff-inter-extrabold);
   --hero-text-ff: var(--ff-subheadings-medium);
   --hero-btn-ff: var(--ff-body-bold);
   --hero-text-size: 20px;

--- a/blocks/inventory/inventory.css
+++ b/blocks/inventory/inventory.css
@@ -23,7 +23,7 @@
 }
 
 .inventory.block h1 {
-  font: 60px/60px var(--ff-helvetica-heavy);
+  font: 60px/60px var(--ff-inter-extrabold);
   padding: 0 !important;
 }
 

--- a/blocks/performance-specifications/performance-specifications.js
+++ b/blocks/performance-specifications/performance-specifications.js
@@ -125,7 +125,7 @@ const updateChart = async (chartContainer, performanceData) => {
   const option = {
     legend: {
       icon: 'circle',
-      fontFamily: 'Helvetica Neue LT Pro 75 Bold',
+      fontFamily: 'Inter 75 Bold',
       top: 'top',
       left: MQ.matches ? 'auto' : '0',
       right: MQ.matches ? '0' : 'auto',

--- a/blocks/v2-dealer-locator/v2-dealer-locator.css
+++ b/blocks/v2-dealer-locator/v2-dealer-locator.css
@@ -239,7 +239,7 @@ main .section.v2-dealer-locator-container>div {
 
 .v2-dealer-locator .tooltip .tooltiptext {
   visibility: hidden;
-  font-family: Arial, sans-serif;
+  font-family: var(--fallback-ff-default);
   width: 120px;
   background-color: #000;
   font-size: 12px;
@@ -1953,7 +1953,7 @@ main .section.v2-dealer-locator-container>div {
   line-height: 18px;
   padding-left: 4px;
   font-size: 15px;
-  font-family: Arial, sans-serif
+  font-family: var(--fallback-ff-default);
 }
 
 .v2-dealer-locator .sidebar .panel-card .panel-container button .icon {

--- a/blocks/v2-dealer-locator/versions/default/sidebar-maps.js
+++ b/blocks/v2-dealer-locator/versions/default/sidebar-maps.js
@@ -2823,7 +2823,7 @@ $.fn.drawPin = function (text, width, height, color) {
     color = '85754d';
   }
 
-  return 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22' + width + '%22%20height%3D%22' + height + '%22%20viewBox%3D%220%200%2038%2038%22%3E%3Cpath%20fill%3D%22%23' + color + '%22%20stroke%3D%22%23ccc%22%20stroke-width%3D%22.5%22%20d%3D%22M34.305%2016.234c0%208.83-15.148%2019.158-15.148%2019.158S3.507%2025.065%203.507%2016.1c0-8.505%206.894-14.304%2015.4-14.304%208.504%200%2015.398%205.933%2015.398%2014.438z%22%2F%3E%3Ctext%20transform%3D%22translate%2819%2018.5%29%22%20fill%3D%22%23fff%22%20style%3D%22font-family%3A%20Arial%2C%20sans-serif%3Bfont-weight%3Abold%3Btext-align%3Acenter%3B%22%20font-size%3D%2212%22%20text-anchor%3D%22middle%22%3E' + text + '%3C%2Ftext%3E%3C%2Fsvg%3E';
+  return 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22' + width + '%22%20height%3D%22' + height + '%22%20viewBox%3D%220%200%2038%2038%22%3E%3Cpath%20fill%3D%22%23' + color + '%22%20stroke%3D%22%23ccc%22%20stroke-width%3D%22.5%22%20d%3D%22M34.305%2016.234c0%208.83-15.148%2019.158-15.148%2019.158S3.507%2025.065%203.507%2016.1c0-8.505%206.894-14.304%2015.4-14.304%208.504%200%2015.398%205.933%2015.398%2014.438z%22%2F%3E%3Ctext%20transform%3D%22translate%2819%2018.5%29%22%20fill%3D%22%23fff%22%20style%3D%22font-family%3A%20Inter%2C%20sans-serif%3Bfont-weight%3Abold%3Btext-align%3Acenter%3B%22%20font-size%3D%2212%22%20text-anchor%3D%22middle%22%3E' + text + '%3C%2Ftext%3E%3C%2Fsvg%3E';
 };
 
 $.fn.handleLocationError = function (browserHasGeolocation, infoWindow, pos) {

--- a/blocks/v2-dealer-locator/versions/export/sidebar-maps.js
+++ b/blocks/v2-dealer-locator/versions/export/sidebar-maps.js
@@ -2611,7 +2611,7 @@ $.fn.drawPin = function (text, width, height, color) {
     color = '85754d';
   }
 
-  return 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22' + width + '%22%20height%3D%22' + height + '%22%20viewBox%3D%220%200%2038%2038%22%3E%3Cpath%20fill%3D%22%23' + color + '%22%20stroke%3D%22%23ccc%22%20stroke-width%3D%22.5%22%20d%3D%22M34.305%2016.234c0%208.83-15.148%2019.158-15.148%2019.158S3.507%2025.065%203.507%2016.1c0-8.505%206.894-14.304%2015.4-14.304%208.504%200%2015.398%205.933%2015.398%2014.438z%22%2F%3E%3Ctext%20transform%3D%22translate%2819%2018.5%29%22%20fill%3D%22%23fff%22%20style%3D%22font-family%3A%20Arial%2C%20sans-serif%3Bfont-weight%3Abold%3Btext-align%3Acenter%3B%22%20font-size%3D%2212%22%20text-anchor%3D%22middle%22%3E' + text + '%3C%2Ftext%3E%3C%2Fsvg%3E';
+  return 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22' + width + '%22%20height%3D%22' + height + '%22%20viewBox%3D%220%200%2038%2038%22%3E%3Cpath%20fill%3D%22%23' + color + '%22%20stroke%3D%22%23ccc%22%20stroke-width%3D%22.5%22%20d%3D%22M34.305%2016.234c0%208.83-15.148%2019.158-15.148%2019.158S3.507%2025.065%203.507%2016.1c0-8.505%206.894-14.304%2015.4-14.304%208.504%200%2015.398%205.933%2015.398%2014.438z%22%2F%3E%3Ctext%20transform%3D%22translate%2819%2018.5%29%22%20fill%3D%22%23fff%22%20style%3D%22font-family%3A%20Inter%2C%20sans-serif%3Bfont-weight%3Abold%3Btext-align%3Acenter%3B%22%20font-size%3D%2212%22%20text-anchor%3D%22middle%22%3E' + text + '%3C%2Ftext%3E%3C%2Fsvg%3E';
 };
 
 $.fn.handleLocationError = function (browserHasGeolocation, infoWindow, pos) {

--- a/constants.json
+++ b/constants.json
@@ -18,7 +18,7 @@
           },
           {
               "name": "v1SectionClasses",
-              "value": "[\"background\",\"background-top\",\"bg-paper\",\"bg-white-paper\",\"dark-background\",\"center\",\"flex-center\",\"font-l\",\"font-m\",\"font-s\",\"font-xl\",\"font-xxl\",\"font-xs\",\"font-xxs\",\"helvetica-55\",\"helvetica-65\",\"helvetica-75\",\"helvetica-56\",\"helvetica-66\",\"helvetica-76\",\"gap\",\"highlight\",\"line-separator\",\"magazine-listing-content\",\"no-first-line\",\"padding-0\",\"padding-16\",\"padding-32\",\"section-width\",\"text-white\",\"text-black\",\"responsive-title\",\"title-line\",\"title-margin-bottom-0\",\"title-white\",\"wrapper-margin-top-0\"]"
+              "value": "[\"background\",\"background-top\",\"bg-paper\",\"bg-white-paper\",\"dark-background\",\"center\",\"flex-center\",\"font-l\",\"font-m\",\"font-s\",\"font-xl\",\"font-xxl\",\"font-xs\",\"font-xxs\",\"font-55\",\"font-65\",\"font-75\",\"font-56\",\"font-66\",\"font-76\",\"gap\",\"highlight\",\"line-separator\",\"magazine-listing-content\",\"no-first-line\",\"padding-0\",\"padding-16\",\"padding-32\",\"section-width\",\"text-white\",\"text-black\",\"responsive-title\",\"title-line\",\"title-margin-bottom-0\",\"title-white\",\"wrapper-margin-top-0\"]"
           },
           {
               "name": "v2SectionClasses",

--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -86,14 +86,14 @@
 
 /* Alternate Fonts */
 @font-face {
-  font-family: 'Arial Regular Text Fallback';
-  src: local(arial);
+  font-family: 'Inter Regular Text Fallback';
+  src: local(inter);
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Arial Bold Headline Fallback';
-  src: local(arial);
+  font-family: 'Inter Bold Headline Fallback';
+  src: local(inter);
   font-weight: bold;
   font-display: swap;
 }

--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -24,46 +24,54 @@
 
 /* Subheads, Body Copy, & Legal Copy */
 @font-face {
-  font-family: 'Helvetica Neue LT Pro 55 Roman';
-  src: url('../fonts/HelveticaNeueLTPro-55Roman.otf') format('opentype');
+  font-family: 'Inter 55 Regular';
+  src: url('https://fonts.googleapis.com/css2?family=Inter:wght@400&display=swap') format('woff2');
+  font-weight: 400;
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Helvetica Neue LT Pro 65 Medium';
-  src: url('../fonts/HelveticaNeueLTPro-65Md.otf') format('opentype');
+  font-family: 'Inter 65 Medium';
+  src: url('https://fonts.googleapis.com/css2?family=Inter:wght@500&display=swap') format('woff2');
+  font-weight: 500;
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Helvetica Neue LT Pro 75 Bold';
-  src: url('../fonts/HelveticaNeueLTPro-75Bd.otf') format('opentype');
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Helvetica Neue LT Pro 56 Roman Italic';
-  src: url('../fonts/HelveticaNeueLTPro-56It.otf') format('opentype');
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Helvetica Neue LT Pro 66 Medium Italic';
-  src: url('../fonts/HelveticaNeueLTPro-66MdIt.otf') format('opentype');
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Helvetica Neue LT Pro 76 Bold Italic';
-  src: url('../fonts/HelveticaNeueLTPro-76BdIt.otf') format('opentype');
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Helvetica Neue 85 Heavy';
-  src: url('../fonts/helveticaneueltpro-hv.woff') format('woff');
+  font-family: 'Inter 75 Bold';
+  src: url('https://fonts.googleapis.com/css2?family=Inter:wght@700&display=swap') format('woff2');
   font-weight: 700;
-  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Inter 56 Regular Italic';
+  src: url('https://fonts.googleapis.com/css2?family=Inter:wght@400&style=italic&display=swap') format('woff2');
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Inter 66 Medium Italic';
+  src: url('https://fonts.googleapis.com/css2?family=Inter:wght@500&style=italic&display=swap') format('woff2');
+  font-weight: 500;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Inter 76 Bold Italic';
+  src: url('https://fonts.googleapis.com/css2?family=Inter:wght@700&style=italic&display=swap') format('woff2');
+  font-weight: 700;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Inter 85 ExtraBold';
+  src: url('https://fonts.googleapis.com/css2?family=Inter:wght@800&display=swap') format('woff2');
+  font-weight: 800;
   font-display: swap;
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -8,7 +8,7 @@
   font-family: "fontawesome Fallback";
   font-style: normal;
   font-weight: 400;
-  src: local("Arial");
+  src: local("Inter");
   ascent-override: 93.75%;
   descent-override: 6.25%;
   line-gap-override: 0.00%;
@@ -92,9 +92,10 @@
   /* Font family */
 
   /* Alternate fonts */
-  --fallback-ff-texts: "Arial Regular Text Fallback", helvetica, sans-serif;
-  --fallback-ff-headlines: "Arial Bold Headline Fallback", helvetica, sans-serif;
-  --fallback-ff-accents: "Arial Regular Text Fallback", helvetica, sans-serif;
+  --fallback-ff-default: inter, sans-serif;
+  --fallback-ff-texts: "Inter Regular Text Fallback", helvetica, sans-serif;
+  --fallback-ff-headlines: "Inter Bold Headline Fallback", helvetica, sans-serif;
+  --fallback-ff-accents: "Inter Regular Text Fallback", helvetica, sans-serif;
 
   /* Headlines */
   --ff-headline-medium: "GT America Extended Medium", var(--fallback-ff-headlines);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -93,18 +93,18 @@
 
   /* Alternate fonts */
   --fallback-ff-default: inter, sans-serif;
-  --fallback-ff-texts: "Inter Regular Text Fallback", helvetica, sans-serif;
-  --fallback-ff-headlines: "Inter Bold Headline Fallback", helvetica, sans-serif;
-  --fallback-ff-accents: "Inter Regular Text Fallback", helvetica, sans-serif;
+  --fallback-ff-texts: "Inter Regular Text Fallback", sans-serif;
+  --fallback-ff-headlines: "Inter Bold Headline Fallback", sans-serif;
+  --fallback-ff-accents: "Inter Regular Text Fallback", sans-serif;
 
   /* Headlines */
   --ff-headline-medium: "GT America Extended Medium", var(--fallback-ff-headlines);
   --ff-headline-compressed: "GT America Compressed Regular", var(--fallback-ff-headlines);
-  --ff-subheadings-medium: "Helvetica Neue LT Pro 65 Medium", var(--fallback-ff-texts);
+  --ff-subheadings-medium: "Inter 65 Medium", var(--fallback-ff-texts);
 
   /* Body */
-  --ff-body: "Helvetica Neue LT Pro 55 Roman", var(--fallback-ff-texts);
-  --ff-body-bold: "Helvetica Neue LT Pro 75 Bold", var(--fallback-ff-texts);
+  --ff-body: "Inter 55 Regular", var(--fallback-ff-texts);
+  --ff-body-bold: "Inter 75 Bold", var(--fallback-ff-texts);
   --ff-testimonial: "GT America Extended Regular", var(--fallback-ff-accents);
   --ff-accents: "GT America Mono Regular", var(--fallback-ff-accents);
 
@@ -123,15 +123,15 @@
   --headline-2-line-height: 115%;
   --headline-2-letter-spacing: -2%;
 
-  /* Helvetica Neue LT Pro, 65 Medium, 32px, 115% / 28px, 115% */
+  /* Inter, 65 Medium, 32px, 115% / 28px, 115% */
   --headline-3-font-size: 2.8rem; /* 28px */
   --headline-3-line-height: 115%;
 
-  /* Helvetica Neue LT Pro, 65 Medium, 24px, 140%  */
+  /* Inter, 65 Medium, 24px, 140%  */
   --headline-4-font-size: 2.4rem; /* 24px */
   --headline-4-line-height: 140%;
 
-  /* Helvetica Neue LT Pro, 65 Medium, 18px, 140%  */
+  /* Inter, 65 Medium, 18px, 140%  */
   --headline-5-font-size: 1.8rem; /* 18px */
   --headline-5-line-height: 140%;
 
@@ -148,10 +148,10 @@
   OLD CSS VARIABLES
   */
 
-  --ff-helvetica-heavy: "Helvetica Neue 85 Heavy", var(--fallback-ff-texts);
-  --ff-helvetica-roman-italic: "Helvetica Neue LT Pro 56 Roman Italic", var(--fallback-ff-texts);
-  --ff-helvetica-medium-italic: "Helvetica Neue LT Pro 66 Medium Italic", var(--fallback-ff-texts);
-  --ff-helvetica-bold-italic: "Helvetica Neue LT Pro 76 Bold Italic", var(--fallback-ff-texts);
+  --ff-inter-extrabold: "Inter 85 ExtraBold", var(--fallback-ff-texts);
+  --ff-inter-regular-italic: "Inter 56 Regular Italic", var(--fallback-ff-texts);
+  --ff-inter-medium-italic: "Inter 66 Medium Italic", var(--fallback-ff-texts);
+  --ff-inter-bold-italic: "Inter 76 Bold Italic", var(--fallback-ff-texts);
 
   /* Accent elements */
   --ff-accents-medium: "GT America Mono Medium", var(--fallback-ff-accents);
@@ -816,32 +816,32 @@ main .section.section-width {
   }
 }
 
-main .section.helvetica-55 {
+main .section.font-55 {
   font-family: var(--ff-body);
 }
 
-main .section.helvetica-65 {
+main .section.font-65 {
   font-family: var(--ff-subheadings-medium);
 }
 
-main .section.helvetica-75 {
+main .section.font-75 {
   font-family: var(--ff-body-bold);
 }
 
-main .section.helvetica-56 {
-  font-family: var(--ff-helvetica-roman-italic);
+main .section.font-56 {
+  font-family: var(--ff-inter-regular-italic);
 }
 
-main .section.helvetica-66 {
-  font-family: var(--ff-helvetica-medium-italic);
+main .section.font-66 {
+  font-family: var(--ff-inter-medium-italic);
 }
 
-main .section.helvetica-76 {
-  font-family: var(--ff-helvetica-bold-italic);
+main .section.font-76 {
+  font-family: var(--ff-inter-bold-italic);
 }
 
 main .section.responsive-title h1 {
-  font-family: var(--ff-helvetica-heavy);
+  font-family: var(--ff-inter-extrabold);
   font-size: var(--heading-2-mobile-size-l);
 }
 
@@ -871,13 +871,13 @@ main .section.responsive-title h1 {
   /* GT America, Extended Medium, 32px, 115%, -2% / 28px, 115%, -2% */
   --headline-2-font-size: 1.75rem; /* 28px */
 
-  /* Helvetica Neue LT Pro, 65 Medium, 32px, 115% / 28px, 115% */
+  /* Inter, 65 Medium, 32px, 115% / 28px, 115% */
   --headline-3-font-size: 1.75rem; /* 28px */
 
-  /* Helvetica Neue LT Pro, 65 Medium, 24px, 140%  */
+  /* Inter, 65 Medium, 24px, 140%  */
   --headline-4-font-size: 1.5rem; /* 24px */
 
-  /* Helvetica Neue LT Pro, 65 Medium, 18px, 140%  */
+  /* Inter, 65 Medium, 18px, 140%  */
   --headline-5-font-size: 1.125rem; /* 18px */
 
   /* Body font sizes */
@@ -891,11 +891,11 @@ main .section.responsive-title h1 {
   /* stylelint-disable-next-line number-max-precision */
   --body-font-size-xxs: 0.8125rem; /* 13px */
 
-  /* Helvetica Neue LT Pro, 55 Roman / Helvetica Neue LT Pro, 75 Bold, 16px, 150%  */
+  /* Inter, 55 Regular / Inter, 75 Bold, 16px, 150%  */
   --body-1-font-size: 1rem; /* 16px */
   --body-1-line-height: 150%;
 
-  /* Helvetica Neue LT Pro, 55 Roman / Helvetica Neue LT Pro, 75 Bold, 13px, 160%  */
+  /* Inter, 55 Regular / Inter, 75 Bold, 13px, 160%  */
   /* stylelint-disable-next-line number-max-precision */
   --body-2-font-size: 0.8125rem; /* 13px */
   --body-2-line-height: 160%;
@@ -908,15 +908,15 @@ main .section.responsive-title h1 {
   --accent-2-font-size: 0.875rem; /* 14px */
   --accent-2-line-height: 120%;
 
-  /* Helvetica Neue LT Pro, 75 Bold, 14px, 16px */
+  /* Inter, 75 Bold, 14px, 16px */
   --label-font-size: 0.875rem; /* 14px */
   --label-line-height: 16px;
 
-  /* Helvetica Neue LT Pro, 75 Bold, 14px, 16px */
+  /* Inter, 75 Bold, 14px, 16px */
   --label-font-size-small: 0.75rem; /* 12px */
   --label-line-height-small: 16px;
 
-  /* Helvetica Neue LT Pro, 55 Roman, 14px, 18px */
+  /* Inter, 55 Regular, 14px, 18px */
   --button-font-size: 0.875rem; /* 14px */
   --button-line-height: 18px;
 


### PR DESCRIPTION
# Update

This update swaps _Arial_ and _Helvetica_ fonts to _Inter_. 

Some `constants.json` updates must be made across all export markets to mimic this update because all classes called, e.g. `helvetica-55` and similar ones now will be called `font-55` and so on.

If there is a need to change the font linked to that CSS class again, then no more content work will be needed.

Fix #66

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/
- After: https://66-fr-change-font-css--vg-macktrucks-com--volvogroup.aem.page/
