### PR TITLE
superscript enhancement in v2-tabbed-carousel #69

### DIFF
--- a/blocks/v2-tabbed-carousel/v2-tabbed-carousel.css
+++ b/blocks/v2-tabbed-carousel/v2-tabbed-carousel.css
@@ -68,6 +68,12 @@
   margin-top: 0;
 }
 
+.v2-tabbed-carousel__figure figcaption sup {
+  font-size: 1em;
+  line-height: 0;
+  vertical-align: text-bottom;
+}
+
 /* Navigation */
 .v2-tabbed-carousel__navigation {
   display: flex;

--- a/blocks/v2-tabbed-carousel/v2-tabbed-carousel.js
+++ b/blocks/v2-tabbed-carousel/v2-tabbed-carousel.js
@@ -116,10 +116,12 @@ export default function decorate(block) {
 
       figure.append(tabContent.querySelector('picture'));
 
-      const lastItems = [...tabContent.childNodes].at(-1);
-      if (lastItems.nodeType === Node.TEXT_NODE && lastItems.textContent.trim() !== '') {
+      const figCaptionNodes = [...tabContent.childNodes]
+        .filter((node) => node.nodeType === Node.TEXT_NODE || node.nodeName === 'SUP')
+        .filter((node) => node.textContent.trim() !== '');
+      if (figCaptionNodes) {
         const figureCaption = createElement('figcaption');
-        figureCaption.append(lastItems);
+        figureCaption.append(...figCaptionNodes);
         figure.append(figureCaption);
       }
 

--- a/blocks/v2-tabbed-carousel/v2-tabbed-carousel.js
+++ b/blocks/v2-tabbed-carousel/v2-tabbed-carousel.js
@@ -116,9 +116,9 @@ export default function decorate(block) {
 
       figure.append(tabContent.querySelector('picture'));
 
-      const figCaptionNodes = [...tabContent.childNodes]
-        .filter((node) => node.nodeType === Node.TEXT_NODE || node.nodeName === 'SUP')
-        .filter((node) => node.textContent.trim() !== '');
+      const figCaptionNodes = [...tabContent.childNodes].filter(
+        (node) => (node.nodeType === Node.TEXT_NODE || node.nodeName === 'SUP') && node.textContent.trim() !== '',
+      );
       if (figCaptionNodes) {
         const figureCaption = createElement('figcaption');
         figureCaption.append(...figCaptionNodes);


### PR DESCRIPTION
### Fix #69

Now, an author can use `text` or a `sup` element and the whole text is shown

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/wendy.kruger/bugs#superscript-in-tabbed-carousel
- After: https://69-superscript-enhancement--vg-macktrucks-com--volvogroup.aem.page/drafts/wendy.kruger/bugs#superscript-in-tabbed-carousel