### PR TITLE
Remove Global Scroll-to-Top Button from Website #48

### DIFF
--- a/blocks/dealer-locator/dealer-locator.css
+++ b/blocks/dealer-locator/dealer-locator.css
@@ -2330,6 +2330,10 @@ main .section.dealer-locator-container>div {
   display: initial !important
 }
 
+.mobile-dealer, .mobile-electric-dealer, .mobile-uptime-dealer {
+  display: none !important
+}
+
 @media (max-width: 700px) {
   .dealer-locator .slider-arrow {
     left: 80%

--- a/blocks/dealer-locator/dealer-locator.css
+++ b/blocks/dealer-locator/dealer-locator.css
@@ -2330,10 +2330,6 @@ main .section.dealer-locator-container>div {
   display: initial !important
 }
 
-#scrollToTop, .mobile-dealer, .mobile-electric-dealer, .mobile-uptime-dealer {
-  display: none !important
-}
-
 @media (max-width: 700px) {
   .dealer-locator .slider-arrow {
     left: 80%

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -246,51 +246,6 @@
   color: var(--c-secondary-silver);
 }
 
-/* Scroll to top */
-
-.scroll-to-top-container {
-  padding: 24px;
-  display: block;
-  position: absolute;
-  top: calc(100vh - 1px);
-  right: 0;
-  bottom: 0;
-  z-index: 1;
-  pointer-events: none;
-}
-
-a.scroll-to-top {
-  display: block;
-  border: none;
-  cursor: pointer;
-  padding: 12px;
-  background-color: var(--c-primary-gold);
-  box-shadow: 0 8px 16px rgb(0 0 0 / 30%);
-  position: sticky;
-  top: calc(100vh - 24px - 50px);
-  z-index: 99;
-  pointer-events: all;
-}
-
-.scroll-to-top:hover {
-  background-color: var(--button-secondary-gold-hover);
-}
-
-.scroll-to-top:active {
-  background-color: var(--button-secondary-gold-pressed);
-}
-
-.scroll-to-top:focus-visible {
-  outline: 2px solid var(--border-focus);
-  outline-offset: 2px;
-}
-
-.scroll-to-top svg {
-  transform: rotate(-90deg);
-  height: 24px;
-  width: 24px;
-}
-
 @media (min-width: 1200px) {
   /* Prefooter */
   .prefooter ul {

--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -20,18 +20,6 @@ const CLASSES = {
   legal: 'footer-legal',
 };
 
-function addScrollToTopButton(mainEl) {
-  const scrollToTopButton = document.createRange().createContextualFragment(`
-    <div class="scroll-to-top-container">
-      <a href="#" class="scroll-to-top" title="${getTextLabel('go to top')}">
-        <span class="icon icon-arrow-right" />
-      </a>
-    </div>
-  `);
-
-  mainEl.append(scrollToTopButton);
-}
-
 function findList(ele) {
   if (ele.classList.contains(CLASSES.truckList)) {
     return ele;
@@ -192,8 +180,6 @@ export default async function decorate(block) {
 
   block.innerHTML = '';
   block.append(newFooter);
-
-  addScrollToTopButton(block);
 
   await decorateIcons(block);
   await loadBlock(block);

--- a/blocks/hotspots/hotspots.css
+++ b/blocks/hotspots/hotspots.css
@@ -514,10 +514,6 @@ footer .block.footer {
   padding-bottom: 110px;
 }
 
-footer .block.footer .scroll-to-top {
-  bottom: 55px;
-}
-
 @media (min-width: 897px) {
   #onetrust-consent-sdk #ot-sdk-btn-floating.ot-floating-button {
     bottom: 10px;
@@ -525,9 +521,5 @@ footer .block.footer .scroll-to-top {
 
   footer .block.footer {
     padding-bottom: 10px;
-  }
-
-  footer .block.footer .scroll-to-top {
-    bottom: 20px;
   }
 }

--- a/blocks/v2-dealer-locator/v2-dealer-locator.css
+++ b/blocks/v2-dealer-locator/v2-dealer-locator.css
@@ -2333,10 +2333,6 @@ main .section.v2-dealer-locator-container>div {
   display: initial !important
 }
 
-#scrollToTop, .mobile-dealer, .mobile-electric-dealer, .mobile-uptime-dealer {
-  display: none !important
-}
-
 @media (max-width: 700px) {
   .v2-dealer-locator .slider-arrow {
     left: 80%

--- a/blocks/v2-dealer-locator/v2-dealer-locator.css
+++ b/blocks/v2-dealer-locator/v2-dealer-locator.css
@@ -2333,6 +2333,10 @@ main .section.v2-dealer-locator-container>div {
   display: initial !important
 }
 
+.mobile-dealer, .mobile-electric-dealer, .mobile-uptime-dealer {
+  display: none !important
+}
+
 @media (max-width: 700px) {
   .v2-dealer-locator .slider-arrow {
     left: 80%


### PR DESCRIPTION
### Update

This update removes the injection of the _scroll-to-top_ code added by the footer block. So because the footer added it, all pages are affected by this change.

#

Fix #48

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/
- After: https://48-remove-scroll-to-top-button--vg-macktrucks-com--volvogroup.aem.page/

Other markets:

Canada:

- Before: https://main--macktrucks-ca--volvogroup.aem.page/
- After: https://48-remove-scroll-to-top-button--macktrucks-ca--volvogroup.aem.page/

Mexico:

- Before: https://main--macktrucks-com-mx--volvogroup.aem.page/
- After: https://48-remove-scroll-to-top-button--macktrucks-com-mx--volvogroup.aem.page/