### PR TITLE
CR: Inter Font Enhancements #151

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -714,8 +714,8 @@ a.header__link {
     border: 1px solid transparent;
     display: inline-flex;
     font-family: var(--ff-subheadings-medium);
-    font-size: 14px;
-    font-weight: normal;
+    font-size: var(--button-font-size);
+    font-weight: var(--button-font-weight);
     gap: 10px;
     justify-content: center;
     letter-spacing: 1.12px;
@@ -743,7 +743,7 @@ a.header__link {
 
     background-color: var(--button-secondary-gold-enabled);
     color: var(--c-primary-black);
-    font-size: 14px;
+    font-size: var(--button-font-size);
   }
 
   .header.block .button.button--primary:hover,
@@ -1031,9 +1031,9 @@ a.header__link {
   .header__main-link-wrapper--tabs-with-cards .header__category-item h3 a.header__link {
     font-family: var(--ff-subheadings-medium);
     font-size: var(--headline-4-font-size);
-    line-height: 130%;
-    letter-spacing: 0.48px;
-    font-weight: normal;
+    font-weight: var(--headline-4-font-weight);
+    line-height: var(--headline-4-line-height);
+    letter-spacing: var(--headline-4-letter-spacing);
   }
 
   /* stylelint-disable-next-line no-descending-specificity */

--- a/blocks/performance-specifications/performance-specifications.css
+++ b/blocks/performance-specifications/performance-specifications.css
@@ -59,8 +59,10 @@
   display: flex;
   font-family: var(--ff-body);
   font-size: var(--body-1-font-size);
+  font-weight: var(--body-1-font-weight);
   justify-content: center;
   line-height: var(--body-1-line-height);
+  letter-spacing: var(--body-1-letter-spacing);
   margin: 0;
   min-width: 160px;
   padding: 20px 15px 10px;

--- a/blocks/v2-accordion-column/v2-accordion-column.css
+++ b/blocks/v2-accordion-column/v2-accordion-column.css
@@ -34,8 +34,9 @@
 .v2-accordion-column__item-title {
   font-family: var(--ff-subheadings-medium);
   font-size: var(--headline-4-font-size);
-  letter-spacing: var(--headline-1-letter-spacing);
-  line-height: var(--headline-1-line-height);
+  font-weight: var(--headline-4-font-weight);
+  line-height: var(--headline-4-line-height);
+  letter-spacing: var(--headline-4-letter-spacing);
   margin: 0;
 }
 

--- a/blocks/v2-accordion/v2-accordion.css
+++ b/blocks/v2-accordion/v2-accordion.css
@@ -87,6 +87,7 @@
   /* Styles for nested accordion */
   .v2-accordion__content .v2-accordion__title {
     font-size: var(--headline-4-font-size);
+    font-weight: var(--headline-4-font-weight);
     letter-spacing: var(--headline-4-letter-spacing);
     line-height: var(--headline-4-line-height);
   }

--- a/blocks/v2-cards/v2-cards.css
+++ b/blocks/v2-cards/v2-cards.css
@@ -54,13 +54,17 @@
 .v2-cards__heading {
   font-family: var(--ff-subheadings-medium);
   font-size: var(--headline-5-font-size);
+  font-weight: var(--headline-5-font-weight);
   line-height: var(--headline-5-line-height);
+  letter-spacing: var(--headline-5-letter-spacing);
   margin: 0 0 7px;
 }
 
 .v2-cards--large-heading .v2-cards__heading {
   font-size: var(--headline-4-font-size);
+  font-weight: var(--headline-4-font-weight);
   line-height: var(--headline-4-line-height);
+  letter-spacing: var(--headline-4-letter-spacing);
 }
 
 .v2-cards__text-wrapper p {
@@ -68,8 +72,9 @@
   font-family: var(--ff-body);
   font-size: var(--body-1-font-size);
   font-style: normal;
+  font-weight: var(--body-1-font-weight);
   line-height: var(--body-1-line-height);
-  letter-spacing: 0.16px;
+  letter-spacing: var(--body-1-letter-spacing);
 }
 
 .v2-cards__text-wrapper strong {
@@ -144,7 +149,9 @@
 
 .v2-cards.v2-cards--spaced .v2-cards__heading {
   font-size: var(--headline-4-font-size);
+  font-weight: var(--headline-4-font-weight);
   line-height: var(--headline-4-line-height);
+  letter-spacing: var(--headline-4-letter-spacing);
 }
 
 .v2-cards.v2-cards--spaced strong {

--- a/blocks/v2-columns/v2-columns.css
+++ b/blocks/v2-columns/v2-columns.css
@@ -74,6 +74,9 @@
 
 .v2-columns__column--with-text .v2-columns__body {
   font-size: var(--body-1-font-size);
+  font-weight: var(--body-1-font-weight);
+  line-height: var(--body-1-line-height);
+  letter-spacing: var(--body-1-letter-spacing);
   margin-top: 0;
   margin-bottom: 0;
 }
@@ -171,9 +174,10 @@
   text-transform: uppercase;
   color: var(--c-tertiary-cool-gray);
   font-family: var(--ff-body-bold);
+  font-weight: var(--label-font-weight-small);
   font-size: var(--label-font-size-small);
   line-height: var(--label-line-height-small);
-  letter-spacing: 1.92px;
+  letter-spacing: var(--label-letter-spacing-small);
   margin: 0 0 24px;
 }
 

--- a/blocks/v2-hero/v2-hero.css
+++ b/blocks/v2-hero/v2-hero.css
@@ -282,7 +282,7 @@
   font-family: var(--ff-accents);
   font-size: var(--body-2-font-size);
   text-transform: uppercase;
-  letter-spacing: .08rem;
+  letter-spacing: var(--body-2-letter-spacing);
 }
 
 [data-page='pdp'] .v2-hero__heading {
@@ -341,6 +341,9 @@
   background: transparent;
   font-family: var(--ff-body-bold);
   font-size: var(--body-1-font-size);
+  font-weight: var(--body-1-font-weight-bold);
+  line-height: var(--body-1-line-height);
+  letter-spacing: var(--body-1-letter-spacing-bold);
 }
 
 [data-page='pdp'] .v2-hero__cta-wrapper {

--- a/blocks/v2-hotspots/v2-hotspots.css
+++ b/blocks/v2-hotspots/v2-hotspots.css
@@ -66,7 +66,9 @@
 
 .v2-hotspots-container .hotspot .hotspot-content h1 {
   font-size: var(--headline-3-font-size);
-  letter-spacing: -0.035em;
+  font-weight: var(--headline-3-font-weight);
+  line-height: var(--headline-3-line-height);
+  letter-spacing: var(--headline-3-letter-spacing);
   margin: 40px 0;
   text-align: left;
 }
@@ -201,7 +203,9 @@
 
 .v2-hotspots .features .feature-title {
   font-size: var(--headline-3-font-size);
+  font-weight: var(--headline-3-font-weight);
   line-height: var(--headline-3-line-height);
+  letter-spacing: var(--headline-3-letter-spacing);
   margin: 0;
 }
 

--- a/blocks/v2-icon-cards/v2-icon-cards.css
+++ b/blocks/v2-icon-cards/v2-icon-cards.css
@@ -99,7 +99,7 @@
 
 .v2-icon-cards--alt-font-size .v2-icon-cards__body {
   font-size: var(--body-1-font-size);
-  font-weight: var(--body-2-font-weight);
+  font-weight: var(--body-1-font-weight);
   line-height: var(--body-1-line-height);
   letter-spacing: var(--body-1-letter-spacing);
 }

--- a/blocks/v2-icon-cards/v2-icon-cards.css
+++ b/blocks/v2-icon-cards/v2-icon-cards.css
@@ -80,14 +80,28 @@
   line-height: var(--body-2-line-height);
 }
 
+.v2-icon-cards__heading:not(.h2) {
+  letter-spacing: var(--body-2-letter-spacing-bold);
+  font-weight: var(--body-2-font-weight-bold);
+}
+
+.v2-icon-cards__body {
+  font-weight: var(--body-2-font-weight);
+  letter-spacing: var(--body-2-letter-spacing);
+}
+
 .v2-icon-cards--alt-font-size .v2-icon-cards__heading {
   font-size: var(--headline-5-font-size);
+  font-weight: var(--headline-5-font-weight);
   line-height: var(--headline-5-line-height);
+  letter-spacing: var(--headline-5-letter-spacing);
 }
 
 .v2-icon-cards--alt-font-size .v2-icon-cards__body {
   font-size: var(--body-1-font-size);
+  font-weight: var(--body-2-font-weight);
   line-height: var(--body-1-line-height);
+  letter-spacing: var(--body-1-letter-spacing);
 }
 
 .v2-icon-cards:not(.v2-icon-cards--alt-font-size) .v2-icon-cards__heading:not(.h2) {
@@ -202,13 +216,10 @@
 
 /* stylelint-disable-next-line no-descending-specificity */
 .v2-icon-cards--4-cols .v2-icon-cards__heading {
-  font-size: var(--body-2-font-size);
-  line-height: var(--body-2-line-height);
   margin-bottom: 8px;
 }
 
 .v2-icon-cards--4-cols .v2-icon-cards__body {
-  font-size: var(--body-2-font-size);
   margin-bottom: 0;
 }
 

--- a/blocks/v2-images-grid/v2-images-grid.css
+++ b/blocks/v2-images-grid/v2-images-grid.css
@@ -125,6 +125,8 @@
   background: var(--c-primary-white);
   line-height: var(--body-2-line-height);
   font-size: var(--body-2-font-size);
+  font-weight: var(--body-2-font-weight);
+  letter-spacing: var(--body-2-letter-spacing);
 }
 
 .v2-images-grid__carousel-item picture {

--- a/blocks/v2-inpage-navigation/v2-inpage-navigation.css
+++ b/blocks/v2-inpage-navigation/v2-inpage-navigation.css
@@ -58,6 +58,8 @@
   font-family: var(--ff-body-bold);
   font-size: var(--body-2-font-size);
   line-height: var(--body-2-line-height);
+  font-weight: var(--body-2-font-weight-bold);
+  letter-spacing: var(--body-2-letter-spacing-bold);
   margin: 0;
   padding: 10px 20px;
   width: 100%;

--- a/blocks/v2-magazine-tabbed-carousel/v2-magazine-tabbed-carousel.css
+++ b/blocks/v2-magazine-tabbed-carousel/v2-magazine-tabbed-carousel.css
@@ -130,8 +130,11 @@
   margin: 0;
   font-family: var(--ff-headline-medium);
   font-size: var(--headline-4-font-size);
-  line-height: 115%;
+  font-weight: var(--headline-4-font-weight);
+  line-height: var(--headline-4-line-height);
+  letter-spacing: var(--headline-4-letter-spacing);
   display: -webkit-box;
+  line-clamp: 3;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;

--- a/blocks/v2-newsletter/v2-newsletter.css
+++ b/blocks/v2-newsletter/v2-newsletter.css
@@ -1,13 +1,18 @@
 /* Footer styles */
 .footer-newsletter .v2-newsletter__message {
   font-size: var(--body-2-font-size);
-  line-height: 18px;
+  font-weight: var(--body-2-font-weight);
+  line-height: var(--body-2-line-height);
+  letter-spacing: var(--body-2-letter-spacing);
 }
 
 /* Footer form */
 .v2-forms__validation-message {
   display: none;
   font-size: calc(var(--body-2-font-size) - 15%);
+  font-weight: var(--body-2-font-weight);
+  line-height: var(--body-2-line-height);
+  letter-spacing: var(--body-2-letter-spacing);
   color: var(--c-error);
 }
 

--- a/blocks/v2-pencil-promo/v2-pencil-promo.css
+++ b/blocks/v2-pencil-promo/v2-pencil-promo.css
@@ -72,8 +72,8 @@
 
 .v2-pencil-promo__pencil-banner .v2-pencil-promo__content p {
   display: inline;
-  font: var(--headline-4-font-size)/117% var(--ff-subheadings-medium);
-  letter-spacing: .25px;
+  font: var(--headline-4-font-weight) var(--headline-4-font-size)/var(--headline-4-line-height) var(--ff-subheadings-medium);
+  letter-spacing: var(--headline-4-letter-spacing);
 }
 
 .v2-pencil-promo__pencil-banner .icon svg {
@@ -118,7 +118,8 @@
 
 .v2-pencil-promo__promo-banner .v2-pencil-promo__content > p {
   padding: 12px 92px 12px 16px;
-  font: var(--headline-5-font-size)/var(--headline-5-line-height) var(--ff-subheadings-medium);
+  font: var(--headline-5-font-weight) var(--headline-5-font-size)/var(--headline-5-line-height) var(--ff-subheadings-medium);
+  letter-spacing: var(--headline-5-letter-spacing);
   max-width: 433px;
   margin: 0;
   color: var(--text-color);
@@ -164,6 +165,9 @@
 
   .v2-pencil-promo__promo-banner .v2-pencil-promo__content > p {
     font-size: var(--headline-4-font-size);
+    font-weight: var(--headline-4-font-weight);
+    line-height: var(--headline-4-line-height);
+    letter-spacing: var(--headline-4-letter-spacing);
   }
 
   .v2-pencil-promo__promo-banner .v2-pencil-promo__content-wrapper {

--- a/blocks/v2-product-listing/v2-product-listing.css
+++ b/blocks/v2-product-listing/v2-product-listing.css
@@ -183,10 +183,14 @@
   flex-flow: row wrap;
   gap: var(--v2-product-listing-content-gap);
   font-size: var(--v2-product-listing-info-font-size);
+  line-height: var(--body-1-line-height);
+  letter-spacing: var(--body-1-letter-spacing);
 }
 
 .v2-product-listing__detail-list li strong {
   font-family: var(--ff-body-bold);
+  font-weight: var(--body-1-font-weight-bold);
+  letter-spacing: var(--body-1-letter-spacing-bold);
 }
 
 .v2-product-listing--with-dots .v2-product-listing__detail-list li {

--- a/blocks/v2-social-block/v2-social-block.css
+++ b/blocks/v2-social-block/v2-social-block.css
@@ -9,6 +9,9 @@
 .v2-social-block__title {
   font-family: var(--ff-headline-medium);
   font-size: var(--headline-4-font-size);
+  font-weight: var(--headline-4-font-weight);
+  line-height: var(--headline-4-line-height);
+  letter-spacing: var(--headline-4-letter-spacing);
   margin: 0 0 32px;
   color: var(--social-text-color);
   text-align: center;

--- a/blocks/v2-specifications/v2-specifications.css
+++ b/blocks/v2-specifications/v2-specifications.css
@@ -17,8 +17,10 @@
   display: grid;
   font-family: var(--ff-body);
   font-size: var(--body-1-font-size);
+  font-weight: var(--body-1-font-weight);
   gap: 16px;
   line-height: var(--body-1-line-height);
+  letter-spacing: var(--body-1-letter-spacing);
   margin-top: 16px;
 }
 
@@ -41,8 +43,9 @@
   display: block;
   font-family: var(--ff-subheadings-medium);
   font-size: var(--headline-5-font-size);
-  font-weight: normal;
+  font-weight: var(--headline-5-font-weight);
   line-height: var(--headline-5-line-height);
+  letter-spacing: var(--headline-5-letter-spacing);
 }
 
 .v2-specifications__list--subtitle {

--- a/blocks/v2-sub-navigation/v2-sub-navigation.css
+++ b/blocks/v2-sub-navigation/v2-sub-navigation.css
@@ -93,7 +93,9 @@
   display: block;
   font-family: var(--ff-body-bold);
   font-size: var(--body-2-font-size);
+  font-weight: var(--body-2-font-weight-bold);
   line-height: var(--body-2-line-height);
+  letter-spacing: var(--body-2-letter-spacing-bold);
   margin: 0;
   padding: 11.5px 16px 11.5px 24px;
   width: 100%;

--- a/blocks/v2-tabbed-carousel/v2-tabbed-carousel.css
+++ b/blocks/v2-tabbed-carousel/v2-tabbed-carousel.css
@@ -59,7 +59,9 @@
 .v2-tabbed-carousel__figure figcaption p {
   font-family: var(--ff-body);
   font-size: var(--body-1-font-size);
+  font-weight: var(--body-1-font-weight);
   line-height: var(--body-1-line-height);
+  letter-spacing: var(--body-1-letter-spacing);
   margin-bottom: 0;
   text-wrap: balance;
 }
@@ -125,8 +127,10 @@
   display: flex;
   font-family: var(--ff-body);
   font-size: var(--body-1-font-size);
+  font-weight: var(--body-1-font-weight);
   justify-content: center;
   line-height: var(--body-1-line-height);
+  letter-spacing: var(--body-1-letter-spacing);
   margin: 0;
   min-width: 160px;
   padding: 20px 15px 10px;
@@ -173,7 +177,8 @@
 }
 
 .v2-tabbed-carousel__text {
-  font: var(--body-2-font-size)/var(--body-2-line-height) var(--ff-body);
+  font: var(--body-2-font-weight) var(--body-2-font-size)/var(--body-2-line-height) var(--ff-body);
+  letter-spacing: var(--body-2-letter-spacing);
 }
 
 @media (min-width: 1200px) {
@@ -211,7 +216,8 @@
 
   .v2-tabbed-carousel__text {
     font-size: var(--body-1-font-size);
-    letter-spacing: 0.16px;
+    font-weight: var(--body-1-font-weight);
+    letter-spacing: var(--body-1-letter-spacing);
     line-height: var(--body-1-line-height);
   }
 }

--- a/blocks/v2-testimonial/v2-testimonial.css
+++ b/blocks/v2-testimonial/v2-testimonial.css
@@ -31,8 +31,8 @@
   gap: var(--testimonial-gap);
   background-color: var(--card-background);
   color: var(--text-color);
-  font: var(--body-2-font-size)/var(--body-2-line-height) var(--ff-body);
-  letter-spacing: 0.3px;
+  font: var(--body-2-font-weight) var(--body-2-font-size)/var(--body-2-line-height) var(--ff-body);
+  letter-spacing: var(--body-2-letter-spacing);
 }
 
 .v2-testimonial__blockquote-container > *,
@@ -77,7 +77,8 @@
   display: flex;
   align-items: center;
   gap: 16px;
-  font: var(--body-2-font-size)/var(--body-2-line-height) var(--ff-body);
+  font: var(--body-2-font-weight) var(--body-2-font-size)/var(--body-2-line-height) var(--ff-body);
+  letter-spacing: var(--body-2-letter-spacing);
 }
 
 .v2-testimonial__video-section svg {

--- a/blocks/v2-truck-builder/v2-truck-builder.css
+++ b/blocks/v2-truck-builder/v2-truck-builder.css
@@ -129,8 +129,9 @@
 .v2-truck-builder__item-title {
   font-family: var(--ff-subheadings-medium);
   font-size: var(--headline-5-font-size);
-  letter-spacing: 0.036em;
-  line-height: var(--headline-1-line-height);
+  font-weight: var(--headline-5-font-weight);
+  letter-spacing: var(--headline-5-letter-spacing);
+  line-height: var(--headline-5-line-height);
   margin: 0;
   width: 100%;
   text-align: left;

--- a/blocks/v2-truck-lineup/v2-truck-lineup.css
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.css
@@ -200,7 +200,9 @@ ul.v2-truck-lineup__navigation {
   display: flex;
   font-family: var(--ff-subheadings-medium);
   font-size: var(--headline-5-font-size);
+  font-weight: var(--headline-5-font-weight);
   line-height: var(--headline-5-line-height);
+  letter-spacing: var(--headline-5-letter-spacing);
   margin: 0 0 0 20px;
   padding: 14px 0;
   text-wrap: nowrap;
@@ -305,7 +307,9 @@ ul.v2-truck-lineup__navigation {
 @media screen and (min-width: 744px) {
   .v2-truck-lineup__navigation-item button {
     font-size: var(--headline-4-font-size);
+    font-weight: var(--headline-4-font-weight);
     line-height: var(--headline-4-line-height);
+    letter-spacing: var(--headline-4-letter-spacing);
   }
 
   .v2-truck-lineup__arrow-controls {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -91,6 +91,27 @@
 
   /* Font family */
 
+  /*
+  **Inter renamed from Helvetica Neue LT Pro:
+  Inter 55 Regular: weight 400
+  Inter 65 Medium: weight 500
+  Inter 75 Bold: weight 700
+  Inter 85 ExtraBold: weight 800
+  Inter 56 Regular Italic
+  Inter 66 Medium Italic
+  Inter 76 Bold Italic
+
+  **New Inter naming:
+  Inter Medium: weight 500
+  Inter SemiBold: weight 600
+  Inter Bold: weight 700
+  */
+
+  /* Font Weights */
+  --fw-medium: 500;
+  --fw-semibold: 600;
+  --fw-bold: 700;
+
   /* Alternate fonts */
   --fallback-ff-default: "Inter", sans-serif;
   --fallback-ff-texts: "Inter", sans-serif;
@@ -103,7 +124,7 @@
   --ff-subheadings-medium: "Inter 65 Medium", var(--fallback-ff-texts);
 
   /* Body */
-  --ff-body: "Inter 55 Regular", var(--fallback-ff-texts);
+  --ff-body: "Inter 65 Medium", var(--fallback-ff-texts);
   --ff-body-bold: "Inter 75 Bold", var(--fallback-ff-texts);
   --ff-testimonial: "GT America Extended Regular", var(--fallback-ff-accents);
   --ff-accents: "GT America Mono Regular", var(--fallback-ff-accents);
@@ -116,24 +137,30 @@
   /* GT America, Extended Medium, 45px, 115%, -2% / 32px, 115%, -2% */
   --headline-1-font-size: 3.2rem; /* 32px */
   --headline-1-line-height: 115%;
-  --headline-1-letter-spacing: -2%;
+  --headline-1-letter-spacing: -0.02rem; /* -0.32px */
 
   /* GT America, Extended Medium, 32px, 115%, -2% / 28px, 115%, -2% */
   --headline-2-font-size: 2.8rem; /* 28px */
   --headline-2-line-height: 115%;
-  --headline-2-letter-spacing: -2%;
+  --headline-2-letter-spacing: -0.02rem; /* -0.32px */
 
-  /* Inter, 65 Medium, 32px, 115% / 28px, 115% */
+  /* Inter, Semi Bold, 28px, 115%, 0% / 31px, 118%, 0% */
   --headline-3-font-size: 2.8rem; /* 28px */
   --headline-3-line-height: 115%;
+  --headline-3-font-weight: var(--fw-semibold);
+  --headline-3-letter-spacing: 0;
 
-  /* Inter, 65 Medium, 24px, 140%  */
+  /* Inter, Semi Bold, 24px, 140%, 0.5%  */
   --headline-4-font-size: 2.4rem; /* 24px */
   --headline-4-line-height: 140%;
+  --headline-4-font-weight: var(--fw-semibold);
+  --headline-4-letter-spacing: 0.005rem; /* 0.08px */
 
-  /* Inter, 65 Medium, 18px, 140%  */
+  /* Inter, Semi Bold, 18px, 140%, 0%  */
   --headline-5-font-size: 1.8rem; /* 18px */
   --headline-5-line-height: 140%;
+  --headline-5-font-weight: var(--fw-semibold);
+  --headline-5-letter-spacing: 0;
 
   /* Wrapper for generic components */
   --wrapper-width: 1040px;
@@ -344,7 +371,7 @@ pre {
   padding: 5px 30px;
   text-align: center;
   font-style: normal;
-  font-weight: 600;
+  font-weight: var(--button-font-weight);
   cursor: pointer;
   color: var(--background-color);
   background-color: var(--link-color);
@@ -871,13 +898,13 @@ main .section.responsive-title h1 {
   /* GT America, Extended Medium, 32px, 115%, -2% / 28px, 115%, -2% */
   --headline-2-font-size: 1.75rem; /* 28px */
 
-  /* Inter, 65 Medium, 32px, 115% / 28px, 115% */
+  /* Inter, Semi Bold, 31px, 115%, 0% / 28px, 118%, 0% */
   --headline-3-font-size: 1.75rem; /* 28px */
 
-  /* Inter, 65 Medium, 24px, 140%  */
+  /* Inter, Semi Bold, 24px, 140%  */
   --headline-4-font-size: 1.5rem; /* 24px */
 
-  /* Inter, 65 Medium, 18px, 140%  */
+  /* Inter, Semi Bold, 18px, 140%, 0%  */
   --headline-5-font-size: 1.125rem; /* 18px */
 
   /* Body font sizes */
@@ -891,14 +918,22 @@ main .section.responsive-title h1 {
   /* stylelint-disable-next-line number-max-precision */
   --body-font-size-xxs: 0.8125rem; /* 13px */
 
-  /* Inter, 55 Regular / Inter, 75 Bold, 16px, 150%  */
+  /* Inter, Medium, 16px, 150%, -1.5% / Inter, Bold, 16px, 150%, 0.5%  */
   --body-1-font-size: 1rem; /* 16px */
   --body-1-line-height: 150%;
+  --body-1-font-weight: var(--fw-medium);
+  --body-1-letter-spacing: -0.015rem; /* -0.24px */
+  --body-1-font-weight-bold: var(--fw-bold);
+  --body-1-letter-spacing-bold: 0.005rem; /* 0.08px */
 
-  /* Inter, 55 Regular / Inter, 75 Bold, 13px, 160%  */
+  /* Inter, Medium, 13px, 160%, -3% / Inter, Bold, 13px, 160%, -0.5%  */
   /* stylelint-disable-next-line number-max-precision */
   --body-2-font-size: 0.8125rem; /* 13px */
   --body-2-line-height: 160%;
+  --body-2-letter-spacing: -0.03rem; /* -0.48px */
+  --body-2-font-weight: var(--fw-medium);
+  --body-2-letter-spacing-bold: -0.005rem; /* -0.08px */
+  --body-2-font-weight-bold: var(--fw-bold);
 
   /* GT America Mono, Regular, 18px, 120% */
   --accent-1-font-size: 1.125rem; /* 18px */
@@ -908,17 +943,17 @@ main .section.responsive-title h1 {
   --accent-2-font-size: 0.875rem; /* 14px */
   --accent-2-line-height: 120%;
 
-  /* Inter, 75 Bold, 14px, 16px */
-  --label-font-size: 0.875rem; /* 14px */
-  --label-line-height: 16px;
-
-  /* Inter, 75 Bold, 14px, 16px */
+  /* Inter, Bold, 12px, 130% 17% */
   --label-font-size-small: 0.75rem; /* 12px */
-  --label-line-height-small: 16px;
+  --label-line-height-small: 130%;
+  --label-letter-spacing-small: 0.17rem; /* 2.72px */
+  --label-font-weight-small: var(--fw-bold);
 
-  /* Inter, 55 Regular, 14px, 18px */
+  /* Inter, Medium, 14px, 130%, 8% */
   --button-font-size: 0.875rem; /* 14px */
-  --button-line-height: 18px;
+  --button-line-height: 130%;
+  --button-letter-spacing: 0.08rem; /* 1.28px */
+  --button-font-weight: var(--fw-medium);
 
   /* GT America, Extended Roman, 24px, 120%, -2% / 18px, 120%, -2% */
   --testimonial-font-size: 1.125rem; /* 18px */
@@ -962,7 +997,9 @@ main .section.responsive-title h1 {
 
 .redesign-v2 body {
   font-size: var(--body-1-font-size);
+  font-weight: var(--body-1-font-weight);
   line-height: var(--body-1-line-height);
+  letter-spacing: var(--body-1-letter-spacing);
 }
 
 .redesign-v2 strong,
@@ -998,17 +1035,23 @@ main .section.responsive-title h1 {
 /* stylelint-disable-next-line no-descending-specificity */
 :where(.redesign-v2) h3, .h3 {
   font-size: var(--headline-3-font-size);
+  font-weight: var(--headline-3-font-weight);
   line-height: var(--headline-3-line-height);
+  letter-spacing: var(--headline-3-letter-spacing);
 }
 
 :where(.redesign-v2) h4, .h4 {
   font-size: var(--headline-4-font-size);
+  font-weight: var(--headline-4-font-weight);
   line-height: var(--headline-4-line-height);
+  letter-spacing: var(--headline-4-letter-spacing);
 }
 
 :where(.redesign-v2) h5, .h5 {
   font-size: var(--headline-5-font-size);
+  font-weight: var(--headline-5-font-weight);
   line-height: var(--headline-5-line-height);
+  letter-spacing: var(--headline-5-letter-spacing);
 }
 
 /* ICONS STYLES */
@@ -1048,7 +1091,7 @@ main .section.responsive-title h1 {
 /* stylelint-disable no-descending-specificity */
 .redesign-v2 a.button:any-link,
 .redesign-v2 button {
-  font-weight: normal;
+  font-weight: var(--button-font-weight);
 }
 /* stylelint-enable no-descending-specificity */
 
@@ -1061,10 +1104,10 @@ main .section.responsive-title h1 {
   display: inline-flex;
   font-family: var(--ff-subheadings-medium);
   font-size: var(--button-font-size);
-  font-weight: normal;
+  font-weight: var(--button-font-weight);
   gap: 10px;
   justify-content: center;
-  letter-spacing: 1.12px;
+  letter-spacing: var(--button-letter-spacing);
   line-height: var(--button-line-height);
   min-width: 128px;
   padding: 12px 20px 8px;
@@ -1393,8 +1436,9 @@ main .section.responsive-title h1 {
   display: inline-flex;
   font-family: var(--ff-subheadings-medium);
   font-size: var(--button-font-size);
+  font-weight: var(--button-font-weight);
   gap: 4px;
-  letter-spacing: 1.12px;
+  letter-spacing: var(--button-letter-spacing);
   line-height: var(--button-line-height);
   background: transparent;
 }
@@ -1474,7 +1518,8 @@ main .section.responsive-title h1 {
     /* stylelint-disable-next-line number-max-precision */
     --headline-1-font-size: 2.8125rem; /* 45px */
     --headline-2-font-size: 2rem; /* 32px */
-    --headline-3-font-size: 2rem; /* 32px */
+    --headline-3-font-size: 1.9375rem; /* 31px */
+    --headline-3-line-height: 118%;
     --testimonial-font-size: 1.5rem; /* 24px */
     --testimonial-letter-spacing: -0.03rem;
     --section-div-padding: 24px 0;


### PR DESCRIPTION
## Notes

### The following blocks are updated (with simplified CSS selector):
- Header (button, h4 -> `__main-link-wrapper--tabs-with-cards __category-item h3 a__link`)
- Performance Specifications (body-1 -> `.category-tab [role="tab"]`)
- V2 Accordion Column (h4 -> `__item-title`)
- V2 Accordion (h4 -> `__title`)
- V2 Cards (h5 -> `__heading`, h4 -> `--large-heading __heading`, body-1 -> `__text-wrapper p`, h4 -> `--spaced __heading`)
- V2 columns (body-1 -> `__body`, label -> `list-title`)
- V2 Hero (body-2 -> `__content 3rdLi`, body-1 -> `pdp page cta`)
- V2 Hotspots (h3 -> `hotspot h1`, h3 -> `feature-title`)
- V2 Icon Cards (body-2-bold -> `__heading Not h2`, body-2 -> `__body`, h5 -> `__heading`)
- V2 Images Grid (body-2 -> `__carousel-item p`)
- V2 Inpage Navigation (body-2 -> `__selected-item-wrapper`)
- V2 Magazine Tabbed Carousel (h4 -> `title`)
- V2 Newsletter (body-2 -> `__message`, `__validation-message`)
- V2 Pencil Promo (h4 -> `__pencil-banner __content p`, h5 & h4 -> `__promo-banner __content p`)
- V2 Product listing (body-1 -> `__detail-list li`, body-1-bold -> `detail-list li strong`)
- V2 Social Blocks (h4 -> `__title`)
- V2 Specifications (body-1 -> `list--with-pictures, --with-downloads`, h5 -> `--with-pictures strong`)
- V2 Sub Navigation (body-2-bold -> `__active-item-wrapper`)
- V2 Tabbed Carousel (body-1 -> `__figure figcaption p`& `__navigation button`, body-2 & -1 -> `__text`)
- V2 Testimonial (body-2 -> `__blockquote-container` & `__video-section`)
- V2 Truck Builder (h5 -> `__item-title`)
- V2 Truck Lineup (h5 & h4 -> `__navigation-item button`)

#
Fix #151

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/
- After: https://151-inter-font-enhancements--vg-macktrucks-com--volvogroup.aem.page/