### PR TITLE
FR: Navigation - Addition of an "Industry" tab section to the navigation #178

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -910,7 +910,7 @@ a.header__link {
 
   .header__menu-open > .header__main-link-wrapper--tabs-with-cards > .header__accordion-content-wrapper .header__menu-content a {
     font-family: var(--ff-subheadings-medium);
-    font-size: 24px;
+    font-size: 20px;
     line-height: 140%;
     letter-spacing: 0.48px;
     text-underline-offset: 14px;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -916,18 +916,9 @@ a.header__link {
     text-underline-offset: 14px;
     text-decoration-thickness: 4px;
     padding: 0;
-    position: absolute;
     left: 50%;
     width: max-content;
     cursor: pointer;
-  }
-
-  .header__menu-open > .header__main-link-wrapper--tabs-with-cards > .header__accordion-content-wrapper .header__menu-content:first-child a {
-    transform: translateX(calc(-100% - (var(--menu-cards-gutter) / 2)));
-  }
-
-  .header__menu-open > .header__main-link-wrapper--tabs-with-cards > .header__accordion-content-wrapper .header__menu-content:last-child a {
-    transform: translateX(calc(var(--menu-cards-gutter) / 2));
   }
 
   /* stylelint-disable-next-line no-descending-specificity */


### PR DESCRIPTION

Fix #178

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/
- After: https://178-add-header-tab--vg-macktrucks-com--volvogroup.aem.page/

Other markets:

Canada:

- Before: https://main--macktrucks-ca--volvogroup.aem.page/
- After: https://178-add-header-tab--macktrucks-ca--volvogroup.aem.page/

Mexico:

- Before: https://main--macktrucks-com-mx--volvogroup.aem.page/
- After: https://178-add-header-tab--macktrucks-com-mx--volvogroup.aem.page/