### PR TITLE
V2 Product Listing, the left padding of some text is set too far to the right #18

### DIFF
--- a/blocks/v2-product-listing/v2-product-listing.css
+++ b/blocks/v2-product-listing/v2-product-listing.css
@@ -166,6 +166,7 @@
 .v2-product-listing__detail-list {
   gap: var(--v2-product-listing-content-gap);
   align-items: flex-start;
+  padding-left: 0;
 }
 
 .v2-product-listing--with-dots .v2-product-listing__detail-list {


### PR DESCRIPTION
Fix #18

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-product-listing
- After: https://18-v2-product-listing-padding--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-product-listing