### PR TITLE
FR: V2 Truck Lineup - enhancements #185

### DIFF
--- a/blocks/v2-truck-lineup/v2-truck-lineup.css
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.css
@@ -3,22 +3,6 @@
   --truck-lineup-navigation-icon: 15px;
 }
 
-@keyframes truck-entry {
-  0% {
-    transform: translateX(100%);
-    opacity: 0;
-  }
-
-  25% {
-    opacity: 1;
-  }
-
-  100% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-}
-
 /* Full width block */
 main .section.v2-truck-lineup-container .v2-truck-lineup-wrapper {
   margin: 0;
@@ -71,13 +55,7 @@ main .section.v2-truck-lineup-container {
 }
 
 .v2-truck-lineup__image-item picture {
-  opacity: 0;
   display: block;
-  animation-duration: 1s;
-  animation-delay: 0.5s;
-  animation-name: truck-entry;
-  animation-timing-function: ease-in;
-  animation-fill-mode: forwards;
 }
 
 .v2-truck-lineup__image-item:first-child {

--- a/blocks/v2-truck-lineup/v2-truck-lineup.css
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.css
@@ -15,6 +15,7 @@
 
   100% {
     transform: translateX(0);
+    opacity: 1;
   }
 }
 
@@ -70,7 +71,13 @@ main .section.v2-truck-lineup-container {
 }
 
 .v2-truck-lineup__image-item picture {
+  opacity: 0;
   display: block;
+  animation-duration: 1s;
+  animation-delay: 0.5s;
+  animation-name: truck-entry;
+  animation-timing-function: ease-in;
+  animation-fill-mode: forwards;
 }
 
 .v2-truck-lineup__image-item:first-child {

--- a/blocks/v2-truck-lineup/v2-truck-lineup.css
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.css
@@ -71,10 +71,6 @@ main .section.v2-truck-lineup-container {
 
 .v2-truck-lineup__image-item picture {
   display: block;
-  animation-duration: 1s;
-  animation-delay: 0.5s;
-  animation-name: truck-entry;
-  animation-timing-function: ease-in;
 }
 
 .v2-truck-lineup__image-item:first-child {
@@ -190,7 +186,6 @@ ul.v2-truck-lineup__navigation {
   transform-origin: left;
 }
 
-/* stylelint-disable-next-line no-descending-specificity */
 .v2-truck-lineup__navigation-item button {
   --color-icon: var(--text-subtle);
 
@@ -208,6 +203,17 @@ ul.v2-truck-lineup__navigation {
   text-wrap: nowrap;
   white-space: nowrap;
   transition: none;
+}
+
+.v2-truck-lineup__arrow-controls button {
+  background-color: var(--c-primary-white);
+  border: 1px solid var(--c-primary-black);
+  color: var(--text-color);
+  font-size: 0;
+  line-height: 0;
+  margin: 0;
+  padding: 16px;
+  position: relative;
 }
 
 .v2-truck-lineup__navigation-item.active button,
@@ -267,18 +273,6 @@ ul.v2-truck-lineup__navigation {
 .v2-truck-lineup__arrow-controls li:last-child {
   left: auto;
   right: 10%;
-}
-
-/* stylelint-disable-next-line no-descending-specificity */
-.v2-truck-lineup__arrow-controls button {
-  background-color: var(--c-primary-white);
-  border: 1px solid var(--c-primary-black);
-  color: var(--text-color);
-  font-size: 0;
-  line-height: 0;
-  margin: 0;
-  padding: 16px;
-  position: relative;
 }
 
 .v2-truck-lineup__arrow-controls button:hover {

--- a/blocks/v2-truck-lineup/v2-truck-lineup.css
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.css
@@ -284,13 +284,6 @@ ul.v2-truck-lineup__navigation {
 }
 
 @media screen and (min-width: 744px) {
-  .v2-truck-lineup__navigation-item button {
-    font-size: var(--headline-4-font-size);
-    font-weight: var(--headline-4-font-weight);
-    line-height: var(--headline-4-line-height);
-    letter-spacing: var(--headline-4-letter-spacing);
-  }
-
   .v2-truck-lineup__arrow-controls {
     display: block;
   }

--- a/blocks/v2-truck-lineup/v2-truck-lineup.js
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.js
@@ -175,8 +175,11 @@ export default async function decorate(block) {
 
     // create div for image and append inside image div container
     const picture = tabItem.querySelector('picture');
+    // adds the featured class only to the first featured item even if there are more than one
+    const tabFeatured = tabContent.dataset.truckCarouselFeatured;
+    const hasImageFeatured = imagesContainer.querySelector('.featured');
     const imageItem = createElement('div', {
-      classes: [`${blockName}__image-item`, ...(tabContent.dataset.truckCarouselFeatured ? ['featured'] : [])],
+      classes: [`${blockName}__image-item`, ...(tabFeatured && !hasImageFeatured ? ['featured'] : [])],
     });
 
     imageItem.appendChild(picture);

--- a/blocks/v2-truck-lineup/v2-truck-lineup.js
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.js
@@ -113,11 +113,24 @@ const updateActiveItem = (index) => {
 };
 
 const scrollObserverFunction = (elements, entry) => {
+  // in case the block has a featured item, scroll to it
+  const featuredItem = [...elements].find((el) => el.classList.contains('featured'));
+  const targetElement = featuredItem || entry.target;
+  let idx = 0;
+
   elements.forEach((el, index) => {
-    if (el === entry.target && entry.intersectionRatio >= 0.9) {
+    if (el === targetElement && entry.intersectionRatio >= 0.9) {
+      if (featuredItem) {
+        idx = index;
+      }
       updateActiveItem(index);
     }
   });
+
+  if (featuredItem) {
+    featuredItem.classList.remove('featured');
+    setCarouselPosition(targetElement.parentNode, idx);
+  }
 };
 
 const arrowFragment = document.createRange().createContextualFragment(`<li>
@@ -202,6 +215,10 @@ export default async function decorate(block) {
     }
   });
 
+  if (featuredItem.element) {
+    imagesContainer.children[featuredItem.index].classList.add('featured');
+  }
+
   // update the button indicator on scroll
   const elements = imagesContainer.querySelectorAll(':scope > *');
   listenScroll(imagesContainer, elements, scrollObserverFunction, 0.9);
@@ -215,13 +232,6 @@ export default async function decorate(block) {
       setNavigationLine(tabNavigation);
     }, 100);
   });
-
-  // in case the block has a featured item, scroll to it
-  if (featuredItem.element) {
-    setTimeout(() => {
-      setCarouselPosition(imagesContainer, featuredItem.index);
-    }, 500);
-  }
 
   decorateIcons(block);
 }

--- a/blocks/v2-truck-lineup/v2-truck-lineup.js
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.js
@@ -31,15 +31,11 @@ const setNavigationLine = (tabNavigation) => {
     totalWidth += listItem.getBoundingClientRect().width;
   });
 
+  let borderScale = totalWidth;
   if (totalWidth + 32 <= navWidth) {
-    if (navWidth === 1040 && viewportWidth >= 1200) {
-      tabNavigation.style.setProperty('--truck-lineup-border-scale', `${navWidth}`);
-    } else {
-      tabNavigation.style.setProperty('--truck-lineup-border-scale', `${navWidth - 32}`);
-    }
-  } else {
-    tabNavigation.style.setProperty('--truck-lineup-border-scale', `${totalWidth}`);
+    borderScale = navWidth === 1040 && viewportWidth >= 1200 ? navWidth : navWidth - 32;
   }
+  tabNavigation.style.setProperty('--truck-lineup-border-scale', `${borderScale}`);
 };
 
 function buildTabNavigation(tabItems, clickHandler) {
@@ -155,9 +151,20 @@ export default async function decorate(block) {
 
   descriptionContainer.parentNode.append(tabNavigation);
 
-  tabItems.forEach((tabItem) => {
+  const featuredItem = {
+    index: 0,
+    element: null,
+  };
+
+  tabItems.forEach((tabItem, idx) => {
     tabItem.classList.add(`${blockName}__desc-item`);
     const tabContent = tabItem.querySelector(tabContentClass);
+
+    if (tabContent.dataset.truckCarouselFeatured) {
+      featuredItem.index = idx;
+      featuredItem.element = tabItem;
+    }
+
     const headings = tabContent ? tabContent.querySelectorAll('h1, h2, h3, h4, h5, h6') : [];
     [...headings].forEach((heading) => heading.classList.add(`${blockName}__title`));
 
@@ -208,6 +215,13 @@ export default async function decorate(block) {
       setNavigationLine(tabNavigation);
     }, 100);
   });
+
+  // in case the block has a featured item, scroll to it
+
+  if (featuredItem.element) {
+    console.log('featuredItem', { featuredItem, imagesContainer });
+    setCarouselPosition(imagesContainer, featuredItem.index);
+  }
 
   decorateIcons(block);
 }

--- a/blocks/v2-truck-lineup/v2-truck-lineup.js
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.js
@@ -161,29 +161,24 @@ export default async function decorate(block) {
 
   // Arrows
   createArrowControls(imagesContainer, `.${blockName}__image-item.active`, [`${blockName}__arrow-controls`], arrowFragment);
+  // move arrows to the end of the images container
+  imagesWrapper.append(imagesWrapper.querySelector(`.${blockName}__arrow-controls`));
 
   descriptionContainer.parentNode.append(tabNavigation);
 
-  const featuredItem = {
-    index: 0,
-    element: null,
-  };
-
-  tabItems.forEach((tabItem, idx) => {
+  tabItems.forEach((tabItem) => {
     tabItem.classList.add(`${blockName}__desc-item`);
     const tabContent = tabItem.querySelector(tabContentClass);
-
-    if (tabContent.dataset.truckCarouselFeatured) {
-      featuredItem.index = idx;
-      featuredItem.element = tabItem;
-    }
 
     const headings = tabContent ? tabContent.querySelectorAll('h1, h2, h3, h4, h5, h6') : [];
     [...headings].forEach((heading) => heading.classList.add(`${blockName}__title`));
 
     // create div for image and append inside image div container
     const picture = tabItem.querySelector('picture');
-    const imageItem = createElement('div', { classes: `${blockName}__image-item` });
+    const imageItem = createElement('div', {
+      classes: [`${blockName}__image-item`, ...(tabContent.dataset.truckCarouselFeatured ? ['featured'] : [])],
+    });
+
     imageItem.appendChild(picture);
     imagesContainer.appendChild(imageItem);
 
@@ -214,10 +209,6 @@ export default async function decorate(block) {
       parentButtonContainer.appendChild(buttonContainer);
     }
   });
-
-  if (featuredItem.element) {
-    imagesContainer.children[featuredItem.index].classList.add('featured');
-  }
 
   // update the button indicator on scroll
   const elements = imagesContainer.querySelectorAll(':scope > *');

--- a/blocks/v2-truck-lineup/v2-truck-lineup.js
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.js
@@ -217,10 +217,10 @@ export default async function decorate(block) {
   });
 
   // in case the block has a featured item, scroll to it
-
   if (featuredItem.element) {
-    console.log('featuredItem', { featuredItem, imagesContainer });
-    setCarouselPosition(imagesContainer, featuredItem.index);
+    setTimeout(() => {
+      setCarouselPosition(imagesContainer, featuredItem.index);
+    }, 500);
   }
 
   decorateIcons(block);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -776,6 +776,7 @@ function createTruckLineupSection(tabItems, classname) {
 }
 
 function buildTruckLineupBlock(main, classname) {
+  const truckName = 'data-truck-carousel';
   const tabItems = [];
   let nextElement;
 
@@ -788,13 +789,21 @@ function buildTruckLineupBlock(main, classname) {
 
     // save carousel position
     nextElement = mainChildren[i2 + 1];
-    const sectionMeta = section.dataset.truckCarousel;
-
-    const tabContent = createElement('div', { classes: `${classname}__content` });
-    tabContent.dataset.truckCarousel = sectionMeta;
-    if (section.dataset.truckCarouselIcon) {
-      tabContent.dataset.truckCarouselIcon = section.dataset.truckCarouselIcon;
+    const { truckCarousel, truckCarouselIcon, truckCarouselFeatured } = section.dataset;
+    const props = {
+      [truckName]: truckCarousel,
+    };
+    if (truckCarouselIcon) {
+      props[`${truckName}-icon`] = truckCarouselIcon;
     }
+    if (truckCarouselFeatured) {
+      props[`${truckName}-featured`] = truckCarouselFeatured;
+    }
+
+    const tabContent = createElement('div', {
+      classes: `${classname}__content`,
+      props,
+    });
 
     tabContent.innerHTML = section.innerHTML;
     const image = tabContent.querySelector('p > picture');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -776,7 +776,7 @@ function createTruckLineupSection(tabItems, classname) {
 }
 
 function buildTruckLineupBlock(main, classname) {
-  const truckName = 'data-truck-carousel';
+  const dataTruckCarousel = 'data-truck-carousel';
   const tabItems = [];
   let nextElement;
 
@@ -789,20 +789,16 @@ function buildTruckLineupBlock(main, classname) {
 
     // save carousel position
     nextElement = mainChildren[i2 + 1];
-    const { truckCarousel, truckCarouselIcon, truckCarouselFeatured } = section.dataset;
-    const props = {
-      [truckName]: truckCarousel,
-    };
-    if (truckCarouselIcon) {
-      props[`${truckName}-icon`] = truckCarouselIcon;
-    }
-    if (truckCarouselFeatured) {
-      props[`${truckName}-featured`] = truckCarouselFeatured;
-    }
 
+    // create the tab item and add the icon and/or featured data attributes if they exist
+    const { truckCarousel: truckName, truckCarouselIcon: truckIcon, truckCarouselFeatured: isFeatured } = section.dataset;
     const tabContent = createElement('div', {
       classes: `${classname}__content`,
-      props,
+      props: {
+        [`${dataTruckCarousel}`]: truckName,
+        ...(truckIcon && { [`${dataTruckCarousel}-icon`]: truckIcon }),
+        ...(isFeatured && { [`${dataTruckCarousel}-featured`]: isFeatured }),
+      },
     });
 
     tabContent.innerHTML = section.innerHTML;


### PR DESCRIPTION
# Update

This update adds a new section metadata for the v2-truck-line-up block. The new key value is `Truck carousel featured` and as a value, it needs to use the keyword `active`. This highlights the featured item but keeps the list in its order.

Also, if there is more than 1 featured item, it will highlight the 1st featured item and ignore the rest.

#
Fix #185

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/jlledo/lineup-demo
- After: https://185-v2-truck-lineup-enhancements--vg-macktrucks-com--volvogroup.aem.page/drafts/jlledo/lineup-demo
