### PR TITLE
Bug: Recent articles block wrong links #223

### DIFF
--- a/blocks/recent-articles/recent-articles.js
+++ b/blocks/recent-articles/recent-articles.js
@@ -26,7 +26,7 @@ const createList = (articles) => `
           <a href="${linkUrl}">${pictureTag}</a>
         </div>
         ${idx === 0 && article.category ? `<a class="${blockName}-${firstOrRestClass}-category" href="${categoryUrl}">${article.category}</a>` : ''}
-        <a class="${blockName}-${firstOrRestClass}-title" href="">${article.title}</a>
+        <a class="${blockName}-${firstOrRestClass}-title" href="${linkUrl}">${article.title}</a>
         ${idx === 0 && article.subtitle ? `<p class="${blockName}-${firstOrRestClass}-subtitle">${article.subtitle}</p>` : ''}
         ${idx === 0 ? `<a class="${blockName}-${firstOrRestClass}-link" href="${linkUrl}">${readNowText}</a>` : ''}
       </li>`;


### PR DESCRIPTION
In `recent-articles` block, the title had no href value making it reload the current page. The link has been added now.

Fix #223

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/magazine/categories/in-the-know
- After: https://223-bug-recent-articles--vg-macktrucks-com--volvogroup.aem.page/magazine/categories/in-the-know

