### PR TITLE
Bug: V2 Accordion icon showing in desktop view #224

### DIFF
--- a/blocks/v2-accordion/v2-accordion.css
+++ b/blocks/v2-accordion/v2-accordion.css
@@ -83,6 +83,10 @@
     line-height: var(--headline-2-line-height);
   }
 
+  .v2-accordion .v2-accordion .v2-accordion__icon {
+    display: none;
+  }
+
   /* Styles for nested accordion */
   .v2-accordion__content .v2-accordion__title {
     font-size: var(--headline-4-font-size);


### PR DESCRIPTION
Quick fix to make the unused icon that toggles visibility for mobile view disappear on desktop.

Fix #224

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/trucks/md/#specs
- After: https://224-accordion-icon--vg-macktrucks-com--volvogroup.aem.page/trucks/md/#specs
