### PR TITLE
FR: Add text content to the v2-picture-tooltips block #218

### DIFF
--- a/blocks/v2-picture-tooltips/v2-picture-tooltips.css
+++ b/blocks/v2-picture-tooltips/v2-picture-tooltips.css
@@ -1,9 +1,11 @@
-.v2-picture-tooltips {
-  font-family: var(--ff-accents);
+.v2-picture-tooltips__main-wrapper {
+  display: flex;
+  flex-flow: column-reverse;
 }
 
 .v2-picture-tooltips__picture-wrapper {
   position: relative;
+  margin: 30px 0;
 }
 
 .v2-picture-tooltips__hotspot-wrapper {
@@ -73,6 +75,7 @@
   opacity: 0.5;
   backdrop-filter: blur(10px);
   font-size: 14px;
+  font-family: var(--ff-accents);
 }
 
 .v2-picture-tooltips__hotspot-wrapper .v2-picture-tooltips__tooltip {
@@ -117,6 +120,23 @@
 }
 
 @media (min-width: 744px) {
+  .v2-picture-tooltips__main-wrapper {
+    flex-direction: row;
+    gap: 30px;
+  }
+
+  .v2-picture-tooltips__picture-wrapper {
+    margin: 0;
+  }
+
+  .v2-picture-tooltips__main-wrapper--two-columns .v2-picture-tooltips__picture-wrapper {
+    width: 67%;
+  }
+
+  .v2-picture-tooltips__text-wrapper {
+    width: 33%;
+  }
+
   .v2-picture-tooltips__hotspot {
     width: 24px;
     height: 24px;

--- a/blocks/v2-picture-tooltips/v2-picture-tooltips.css
+++ b/blocks/v2-picture-tooltips/v2-picture-tooltips.css
@@ -3,9 +3,12 @@
   flex-flow: column-reverse;
 }
 
+.v2-picture-tooltips__picture-container {
+  margin: 30px 0;
+}
+
 .v2-picture-tooltips__picture-wrapper {
   position: relative;
-  margin: 30px 0;
 }
 
 .v2-picture-tooltips__hotspot-wrapper {
@@ -125,15 +128,15 @@
     gap: 30px;
   }
 
-  .v2-picture-tooltips__picture-wrapper {
+  .v2-picture-tooltips__picture-container {
     margin: 0;
   }
 
-  .v2-picture-tooltips__main-wrapper--two-columns .v2-picture-tooltips__picture-wrapper {
+  .v2-picture-tooltips__main-wrapper--two-columns .v2-picture-tooltips__picture-container {
     width: 67%;
   }
 
-  .v2-picture-tooltips__text-wrapper {
+  .v2-picture-tooltips__text-container {
     width: 33%;
   }
 

--- a/blocks/v2-picture-tooltips/v2-picture-tooltips.js
+++ b/blocks/v2-picture-tooltips/v2-picture-tooltips.js
@@ -60,7 +60,11 @@ function getBottomStyleClass(coords) {
  * @param {number} hotSpots[].index - The index of the hotspot, used for labeling.
  */
 function decorateBlockWithHotSpots(block, hotSpots) {
+  // Cell with the image:
   const firstBlockCol = block.querySelector(':scope > div > div');
+  // Cell with the html text content:
+  const secondBlockCol = block.querySelector(':scope > div > div:nth-child(2)');
+  const firstBlockRow = block.querySelector(':scope > div');
 
   if (!firstBlockCol) {
     return;
@@ -70,7 +74,13 @@ function decorateBlockWithHotSpots(block, hotSpots) {
 
   const hotspotsTooltip = document.createElement('ol');
   hotspotsTooltip.classList.add(`${BLOCK_NAME}__tooltips-wrapper`);
-  firstBlockCol.insertAdjacentElement('afterend', hotspotsTooltip);
+  firstBlockRow.insertAdjacentElement('afterend', hotspotsTooltip);
+  firstBlockRow.classList.add(`${BLOCK_NAME}__main-wrapper`);
+
+  if (secondBlockCol) {
+    secondBlockCol.classList.add(`${BLOCK_NAME}__text-wrapper`);
+    firstBlockRow.classList.add(`${BLOCK_NAME}__main-wrapper--two-columns`);
+  }
 
   hotSpots.forEach((hotSpot, index) => {
     firstBlockCol.insertAdjacentHTML(
@@ -142,6 +152,18 @@ function assignHotspotClickEvent(block) {
 }
 
 /**
+ * Adds specific CSS classes to all heading elements (h1, h2, h3, h4, h5, h6) within a given block.
+ *
+ * @param {HTMLElement} block - The container element within which to find and decorate heading elements.
+ * @returns {void}
+ */
+function decorateHeadings(block) {
+  const headings = [...block.querySelectorAll('h1, h2, h3, h4, h5, h6')];
+
+  headings.forEach((heading) => heading.classList.add(`${BLOCK_NAME}__heading`, 'with-marker'));
+}
+
+/**
  * Decorates a given block element by extracting hotspots, decorating the block with them,
  * and assigning click events to the hotspots.
  *
@@ -150,6 +172,7 @@ function assignHotspotClickEvent(block) {
 function decorate(block) {
   const hotSpots = extractHotSpotsFrom(block);
 
+  decorateHeadings(block);
   decorateBlockWithHotSpots(block, hotSpots);
 
   assignHotspotClickEvent(block);

--- a/blocks/v2-picture-tooltips/v2-picture-tooltips.js
+++ b/blocks/v2-picture-tooltips/v2-picture-tooltips.js
@@ -158,6 +158,7 @@ function assignHotspotClickEvent(block) {
  * @returns {void}
  */
 function decorateHeadings(block) {
+  // TODO: Move this to common.js and find other usages of this 'with-marker' class
   const headings = [...block.querySelectorAll('h1, h2, h3, h4, h5, h6')];
 
   headings.forEach((heading) => heading.classList.add(`${BLOCK_NAME}__heading`, 'with-marker'));

--- a/blocks/v2-picture-tooltips/v2-picture-tooltips.js
+++ b/blocks/v2-picture-tooltips/v2-picture-tooltips.js
@@ -1,4 +1,4 @@
-import { getTextLabel, isMobileViewport } from '../../scripts/common.js';
+import { createElement, getTextLabel, isMobileViewport } from '../../scripts/common.js';
 
 const BLOCK_NAME = 'v2-picture-tooltips';
 
@@ -65,12 +65,19 @@ function decorateBlockWithHotSpots(block, hotSpots) {
   // Cell with the html text content:
   const secondBlockCol = block.querySelector(':scope > div > div:nth-child(2)');
   const firstBlockRow = block.querySelector(':scope > div');
+  const pictureWrapper = createElement('div', { classes: `${BLOCK_NAME}__picture-wrapper` });
 
   if (!firstBlockCol) {
     return;
   }
 
-  firstBlockCol.classList.add(`${BLOCK_NAME}__picture-wrapper`);
+  firstBlockCol.classList.add(`${BLOCK_NAME}__picture-container`);
+  firstBlockCol.appendChild(pictureWrapper);
+
+  // Move all elements from the first block column to the picture wrapper
+  while (firstBlockCol.firstChild !== pictureWrapper) {
+    pictureWrapper.appendChild(firstBlockCol.firstChild);
+  }
 
   const hotspotsTooltip = document.createElement('ol');
   hotspotsTooltip.classList.add(`${BLOCK_NAME}__tooltips-wrapper`);
@@ -78,12 +85,12 @@ function decorateBlockWithHotSpots(block, hotSpots) {
   firstBlockRow.classList.add(`${BLOCK_NAME}__main-wrapper`);
 
   if (secondBlockCol) {
-    secondBlockCol.classList.add(`${BLOCK_NAME}__text-wrapper`);
+    secondBlockCol.classList.add(`${BLOCK_NAME}__text-container`);
     firstBlockRow.classList.add(`${BLOCK_NAME}__main-wrapper--two-columns`);
   }
 
   hotSpots.forEach((hotSpot, index) => {
-    firstBlockCol.insertAdjacentHTML(
+    pictureWrapper.insertAdjacentHTML(
       'beforeend',
       `
         <div class="${BLOCK_NAME}__hotspot-wrapper ${index === 0 ? 'active' : ''}" data-coords="${hotSpot.coords}" style="${getCoordsStyle(hotSpot.coords)}">


### PR DESCRIPTION
Fix #218
Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/alexis/v2-picture-tooltips-with-text
- After: https://218-picture-tooltips-text--vg-macktrucks-com--volvogroup.aem.page/drafts/alexis/v2-picture-tooltips-with-text

Test URLs of the block without the html text content:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/alexis/v2-picture-tooltips
- After: https://218-picture-tooltips-text--vg-macktrucks-com--volvogroup.aem.page/drafts/alexis/v2-picture-tooltips