### PR TITLE
NFR: Filter Functionality for Dynamically Updating Pencil Promo Block #93

### DIFF
--- a/blocks/v2-pencil-promo/v2-pencil-promo.css
+++ b/blocks/v2-pencil-promo/v2-pencil-promo.css
@@ -1,7 +1,3 @@
-.v2-pencil-promo-container:has(.v2-pencil-promo__pencil-banner) {
-  gap: 0;
-}
-
 .v2-pencil-promo-wrapper.v2-pencil-promo--hidden {
   display: none;
 }
@@ -12,6 +8,10 @@
 
 .v2-pencil-promo {
   --text-color: var(--c-primary-white);
+}
+
+.v2-pencil-promo[data-segment] {
+  margin-bottom: calc(var(--section-gap) * -1);
 }
 
 /* Generic block styles */

--- a/blocks/v2-pencil-promo/v2-pencil-promo.css
+++ b/blocks/v2-pencil-promo/v2-pencil-promo.css
@@ -1,3 +1,11 @@
+.v2-pencil-promo-container:has(.v2-pencil-promo__pencil-banner) {
+  gap: 0;
+}
+
+.v2-pencil-promo-wrapper.v2-pencil-promo--hidden {
+  display: none;
+}
+
 .redesign-v2 .section .v2-pencil-promo-wrapper:not(.full-width) {
   padding: 0 16px;
 }

--- a/blocks/v2-pencil-promo/v2-pencil-promo.js
+++ b/blocks/v2-pencil-promo/v2-pencil-promo.js
@@ -1,5 +1,16 @@
 import { getImageURLs, createResponsivePicture, variantsClassesToBEM, createElement } from '../../scripts/common.js';
 
+function addDataAttributes(element, block) {
+  const dataName = element.querySelector('div:first-child > p');
+  const dataValue = element.querySelector('div:last-child > p');
+  const segment = dataName ? dataName.innerText.trim().toLowerCase() : '';
+  const segmentValue = dataValue ? dataValue.innerText.trim().toLowerCase() : '';
+  if (segment && segmentValue) {
+    block.dataset[segment] = segmentValue;
+  }
+  element.remove();
+}
+
 export default async function decorate(block) {
   const blockName = 'v2-pencil-promo';
   // variant pencil banner black is default
@@ -7,11 +18,23 @@ export default async function decorate(block) {
   const indexVariant = variantClasses.findIndex((variant) => block.classList.contains(variant));
   const currentVariant = (indexVariant >= 0 && variantClasses[indexVariant]) || variantClasses[0];
   const isPencil = currentVariant.includes('pencil');
+  const dataSegment = block.querySelector(':scope > div:nth-child(2)');
+  const isFirstTab = block.querySelector(':scope > div:nth-child(3)');
   variantsClassesToBEM(block.classList, variantClasses, blockName);
+
+  if (dataSegment) {
+    addDataAttributes(dataSegment, block);
+  }
+
+  if (isFirstTab) {
+    addDataAttributes(isFirstTab, block);
+  }
 
   block.classList.add(`${blockName}__${isPencil ? 'pencil' : 'promo'}-banner`);
   if (isPencil) {
-    block.parentElement.classList.add('full-width');
+    const parent = block.parentElement;
+    parent.classList.add('full-width');
+    parent.classList.toggle(`${blockName}--hidden`, !isFirstTab);
   } else {
     block.classList.add(`${blockName}__promo-banner--with-image`);
   }

--- a/blocks/v2-pencil-promo/v2-pencil-promo.js
+++ b/blocks/v2-pencil-promo/v2-pencil-promo.js
@@ -34,7 +34,7 @@ export default async function decorate(block) {
   if (isPencil) {
     const parent = block.parentElement;
     parent.classList.add('full-width');
-    parent.classList.toggle(`${blockName}--hidden`, !isFirstTab);
+    parent.classList.toggle(`${blockName}--hidden`, dataSegment && !isFirstTab);
   } else {
     block.classList.add(`${blockName}__promo-banner--with-image`);
   }

--- a/blocks/v2-product-listing/v2-product-listing.js
+++ b/blocks/v2-product-listing/v2-product-listing.js
@@ -8,7 +8,7 @@ import {
 } from '../../scripts/common.js';
 
 const blockName = 'v2-product-listing';
-const variantClasses = ['with-filter', 'with-dots', 'with-featured', '2-columns'];
+const variantClasses = ['with-filter', 'with-dots', 'with-featured', '2-columns', 'pencil-promo'];
 
 function getActiveFilterButton(block) {
   const AllFilterButtons = block.querySelectorAll(`.${blockName}__button-list .${blockName}__segment-button`);
@@ -113,10 +113,10 @@ function buildSegments(segmentList, allSegmentNames) {
 }
 
 function handFilterClick(e, firstSegment) {
-  const target = e.target;
+  const { target } = e;
   const activeBlock = target.closest(`.${blockName}`);
   const products = activeBlock.querySelectorAll(`.${blockName}__product`);
-  const clickedSegment = e.target.textContent.trim().toLowerCase();
+  const clickedSegment = target.textContent.trim().toLowerCase();
   const selectedItem = activeBlock.querySelector(`.${blockName}__selected-item`);
   selectedItem.textContent = clickedSegment;
 
@@ -128,7 +128,7 @@ function handFilterClick(e, firstSegment) {
   const isFirstSegmentActive = firstSegment === clickedSegment;
   activeBlock.dataset.selected = clickedSegment;
 
-  dropdown.classList[isFirstSegmentActive ? 'add' : 'remove']('initial-state');
+  dropdown.classList.toggle('initial-state', isFirstSegmentActive);
 
   products.forEach((product, idx) => {
     product.style.display = product.classList.contains(clickedSegment) || isFirstSegmentActive ? 'flex' : 'none';
@@ -137,7 +137,7 @@ function handFilterClick(e, firstSegment) {
     product.classList.toggle('selected-product', isSelected);
 
     if (idx === 0) {
-      product.classList[isFirstSegmentActive && hasFeatured ? 'add' : 'remove']('featured');
+      product.classList.toggle('featured', isFirstSegmentActive && hasFeatured);
     }
   });
 
@@ -163,6 +163,17 @@ function handFilterClick(e, firstSegment) {
     } else if (!product.classList.contains('selected-product')) {
       product.classList.remove('odd', 'even');
     }
+  });
+
+  // show/hide pencil promo text blocks depending on the clicked segment if pencil promo variant is present
+  if (!activeBlock.classList.contains(`${blockName}--pencil-promo`)) {
+    return;
+  }
+  const allPencilPromo = activeBlock.closest('.section').querySelectorAll('[data-segment]');
+  allPencilPromo.forEach((promo) => {
+    const promoSegment = promo.dataset.segment.trim().toLowerCase();
+    const isClickedSegment = promoSegment === clickedSegment;
+    promo.parentElement.classList.toggle('v2-pencil-promo--hidden', !isClickedSegment);
   });
 }
 
@@ -199,9 +210,9 @@ function buildFilter(allSegmentNames, firstSegment) {
   return dropdownWrapper;
 }
 
-function handleListeners(dropdownWrapper) {
+function handleListeners(dropdownWrapper, block) {
   // Listener to toggle the dropdown (open / close)
-  document.addEventListener('click', (e) => {
+  block.addEventListener('click', (e) => {
     if (e.target.closest(`.${blockName}__selected-item-wrapper`)) {
       dropdownWrapper.classList.toggle(`${blockName}__dropdown--open`);
     } else {
@@ -250,7 +261,7 @@ export default function decorate(block) {
     dropdownWrapper.dataset.selected = firstSegment;
     dropdownWrapper.classList.add('initial-state');
 
-    handleListeners(dropdownWrapper);
+    handleListeners(dropdownWrapper, block);
     getActiveFilterButton(block);
   } else {
     const detailList = block.querySelectorAll(`.${blockName}__product > div > ul`);


### PR DESCRIPTION
# Update

A list of Pencil Promo blocks as pencil banner variants with text must be added above the product listing block. Also, the product listing block needs a variant "_pencil promo_" to link them all. Every pencil promo block needs to add a config "segment" text to link it with the corresponding segment and, to avoid a content shift, it is essential to add also another 
pencil promo block with the config "_isFirstTab_" as _true_ to be shown at the beginning.

### Fix

after check with the [query site](https://labs.aem.live/tools/site-query/index.html?org=volvogroup&site=vg-macktrucks-com) tool with the following setup:
```
query: .v2-pencil-promo
sitemap: /sitemap.xml
```
the pencil promo shows as expected in all cases

Fix #93

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/jlledo/trucks-demo
- After: https://93-dynamic-pencil-promo-block--vg-macktrucks-com--volvogroup.aem.page/drafts/jlledo/trucks-demo

Current Page:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/trucks/
- After: https://93-dynamic-pencil-promo-block--vg-macktrucks-com--volvogroup.aem.page/trucks/

Another Block use:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/parts-and-services/sir-emissions-information/
- After: https://93-dynamic-pencil-promo-block--vg-macktrucks-com--volvogroup.aem.page/parts-and-services/sir-emissions-information/