### PR TITLE
Improvement: Hiding the "Let's talk" verbiage after a successful form submission #273

### DIFF
--- a/blocks/v2-custom-form/v2-custom-form.js
+++ b/blocks/v2-custom-form/v2-custom-form.js
@@ -48,9 +48,9 @@ async function getCustomMessage(url) {
   return '';
 }
 
-function addHeaderMark(wrapper) {
-  const headerWithMark = wrapper.closest('.header-with-mark');
-  if (headerWithMark) {
+function addHeaderWithMark(wrapper) {
+  const hasHeaderWithMark = wrapper.closest('.header-with-mark');
+  if (hasHeaderWithMark) {
     const title = wrapper.querySelector('h1, h2, h3, h4, h5, h6');
     if (title) {
       title.classList.add('with-marker');
@@ -66,15 +66,15 @@ async function submissionSuccess() {
   successDiv.innerHTML = successMessage(getMessageText(true, true), getMessageText(true, false));
   const form = document.querySelector('form[data-submitting=true]');
   const hasCustomMessage = form.dataset.customMessage;
-  const headerWithMark = form.closest('.header-with-mark');
+  const hasHeaderWithMark = form.closest('.header-with-mark');
 
   if (hasCustomMessage) {
     successDiv.innerHTML = await getCustomMessage(hasCustomMessage);
   }
   form.setAttribute('data-submitting', 'false');
   form.replaceWith(successDiv);
-  if (headerWithMark) {
-    addHeaderMark(successDiv);
+  if (hasHeaderWithMark) {
+    addHeaderWithMark(successDiv);
   }
 }
 
@@ -92,7 +92,7 @@ async function submissionFailure() {
   form.querySelector('button[type="submit"]').disabled = false;
   form.replaceWith(errorDiv);
   if (headerWithMark) {
-    addHeaderMark(errorDiv);
+    addHeaderWithMark(errorDiv);
   }
 }
 
@@ -569,9 +569,9 @@ async function createForm(formURL) {
     e.preventDefault();
     if (isValid) {
       const block = form.closest(`.${blockName}`);
-      const contentText = block.querySelector(`.${blockName}__title`);
-      if (contentText) {
-        contentText.remove();
+      const formTitle = block.querySelector(`.${blockName}__title`);
+      if (formTitle) {
+        formTitle.remove();
       }
       e.submitter.setAttribute('disabled', '');
       form.dataset.action = e.submitter.formAction || SUBMIT_ACTION || pathname.split('.json')[0];
@@ -599,21 +599,21 @@ function decorateTitles(block) {
 
 function addTitleText(titleText, block) {
   const headerWithMark = block.closest('.header-with-mark');
-  const defaultText = headerWithMark?.querySelector('.default-content-wrapper');
+  const defaultContentWrapper = headerWithMark?.querySelector('.default-content-wrapper');
   const titleTextContent = createElement('div', {
     classes: [`${blockName}__title`],
   });
   titleTextContent.innerHTML = titleText.innerHTML;
   block.append(titleTextContent);
-  if (headerWithMark && !defaultText) {
-    addHeaderMark(titleTextContent);
+  if (headerWithMark && !defaultContentWrapper) {
+    addHeaderWithMark(titleTextContent);
   }
 }
 
 export default async function decorate(block) {
   const formLink = block.querySelector('a[href$=".json"]');
   const thankYouPage = [...block.querySelectorAll('a')].filter((a) => a.href.includes('thank-you'));
-  const titleText = block.querySelector(':scope > div:first-child > div');
+  const formTitleContainer = block.querySelector(':scope > div:first-child > div');
 
   if (formLink) {
     decorateTitles(block);
@@ -625,8 +625,8 @@ export default async function decorate(block) {
     // clean the content block before appending the form
     block.innerText = '';
     // add again the content text after the block clean
-    if (titleText) {
-      addTitleText(titleText, block);
+    if (formTitleContainer) {
+      addTitleText(formTitleContainer, block);
     }
     block.append(form);
 


### PR DESCRIPTION
# Fix

Adding a 1st row to the `v2 Custom Form` block with the text (title, subtle and or regular text) makes the block know which text has to be removed when the form is submitted (successfully or with error)

#
Fix #273

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/jlledo/form/title-in-block-form
- After: https://273-hide-title-after-submission--vg-macktrucks-com--volvogroup.aem.page/drafts/jlledo/form/title-in-block-form
