### PR TITLE
FR: MCAE form fields validations #260

### DIFF
--- a/blocks/v2-custom-form/v2-custom-form.js
+++ b/blocks/v2-custom-form/v2-custom-form.js
@@ -241,7 +241,7 @@ function createSubmit(fd) {
 function createInput(fd) {
   const input = createElement('input', {
     props: {
-      // if is email with a pattern, the pattern collides with the browser validation
+      // If the field is an email with a custom pattern, use 'text' to avoid conflicts with browser validation.
       type: fd.Type === 'email' && fd.Pattern ? 'text' : fd.Type,
     },
   });

--- a/blocks/v2-custom-form/v2-custom-form.js
+++ b/blocks/v2-custom-form/v2-custom-form.js
@@ -135,9 +135,10 @@ function setPlaceholder(element, fd) {
 }
 
 const constraintsDef = Object.entries({
-  'email|text': [
+  'email|text|textarea': [
     ['Max', 'maxlength'],
     ['Min', 'minlength'],
+    ['Pattern', 'pattern'],
   ],
   'number|range|date': ['Max', 'Min', 'Step'],
   file: ['Accept', 'Multiple'],
@@ -152,7 +153,7 @@ function setConstraints(element, fd) {
     constraints
       .filter(([nm]) => fd[nm])
       .forEach(([nm, htmlNm]) => {
-        element.setAttribute(htmlNm, fd[nm]);
+        element.setAttribute(htmlNm, htmlNm === 'pattern' ? fd[nm].replace(/^\/|\/$/g, '') : fd[nm]);
       });
   }
 }
@@ -240,7 +241,8 @@ function createSubmit(fd) {
 function createInput(fd) {
   const input = createElement('input', {
     props: {
-      type: fd.Type,
+      // if is email with a pattern, the pattern collides with the browser validation
+      type: fd.Type === 'email' && fd.Pattern ? 'text' : fd.Type,
     },
   });
   setPlaceholder(input, fd);
@@ -256,6 +258,7 @@ const withFieldWrapper = (element) => (fd) => {
 
 const createTextArea = withFieldWrapper((fd) => {
   const textArea = createElement('textarea');
+  setConstraints(textArea, fd);
   setPlaceholder(textArea, fd);
   return textArea;
 });

--- a/blocks/v2-custom-form/v2-custom-form.js
+++ b/blocks/v2-custom-form/v2-custom-form.js
@@ -241,8 +241,7 @@ function createSubmit(fd) {
 function createInput(fd) {
   const input = createElement('input', {
     props: {
-      // If the field is an email with a custom pattern, use 'text' to avoid conflicts with browser validation.
-      type: fd.Type === 'email' && fd.Pattern ? 'text' : fd.Type,
+      type: fd.Type,
     },
   });
   setPlaceholder(input, fd);


### PR DESCRIPTION
# Update

To add more form validations, in the xlsx form config file, 3 more columns need to be added, such as `Pattern`, `Min` & `Max` (case sensitive btw)

### Note

~The email input type collides with a pattern attribute and the built-in pattern in the browser, so in this case, the input is changed to a text type~ it seems that now is working, so no need to change the type.

The pattern can start and end with '/', but because the last versions of Chrome check on validation if the pattern is correct, adding `/v` to the pattern, some but not all special characters need to be escaped in the pattern or the validation breaks.

I reused the same forms from issue 273, so both are sharing the same config JSON file with the new columns added
#
Fix #260

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/jlledo/form/title-in-block-form
- After: https://260-form-fields-validations--vg-macktrucks-com--volvogroup.aem.page/drafts/jlledo/form/title-in-block-form
