### PR TITLE
Bug: Magazines on the Mack Trucks disappeared for the New Zealand site #292

### DIFF
--- a/blocks/explore-articles/explore-articles.js
+++ b/blocks/explore-articles/explore-articles.js
@@ -3,8 +3,9 @@ import { fetchMagazineData, formatArticlesArray, formatFacetsArray } from '../..
 
 const blockName = 'explore-articles';
 
-const queryVariables = { facets: ['ARTICLE', 'TRUCK'], sort: 'PUBLISH_DATE_DESC' };
+const queryVariables = { limit: 100, facets: ['ARTICLE', 'TRUCK'], sort: 'PUBLISH_DATE_DESC' };
 const allMagazineData = await fetchMagazineData(queryVariables);
+const articleCount = allMagazineData?.count || 0;
 const allArticles = formatArticlesArray(allMagazineData?.items);
 const allFacets = formatFacetsArray(allMagazineData?.facets);
 
@@ -13,6 +14,22 @@ const [categoryPlaceholder, truckPlaceholder] = getTextLabel('Article filter pla
 
 let counter = 1;
 const artsPerChunk = 4;
+
+if (articleCount > allArticles.length) {
+  let offset = allArticles.length;
+  while (offset < articleCount) {
+    const newQueryVariables = { ...queryVariables, offset };
+    const newMagazineData = await fetchMagazineData(newQueryVariables);
+    const newItems = formatArticlesArray(newMagazineData?.items || []);
+    allArticles.push(...newItems);
+    offset += newItems.length;
+
+    // Exit loop if no more items are fetched or if the next offset exceeds the article count
+    if (newItems.length === 0 || offset >= articleCount) {
+      break;
+    }
+  }
+}
 
 const divideArray = (mainArray, perChunk) => {
   const dividedArrays = mainArray.reduce((resultArray, item, index) => {

--- a/blocks/explore-articles/explore-articles.js
+++ b/blocks/explore-articles/explore-articles.js
@@ -32,9 +32,6 @@ const getOptions = (list, placeholder) => {
   list.forEach((el) => {
     const option = createElement('option', { props: { value: el } });
     option.innerText = capitalizeWords(el);
-    if (el == 0) {
-      return;
-    }
     if (el.length !== 0) {
       options.push(option);
     }

--- a/blocks/explore-articles/explore-articles.js
+++ b/blocks/explore-articles/explore-articles.js
@@ -3,7 +3,7 @@ import { fetchMagazineData, formatArticlesArray, formatFacetsArray } from '../..
 
 const blockName = 'explore-articles';
 
-const queryVariables = { limit: 100, facets: ['ARTICLE', 'TRUCK'], sort: 'LAST_MODIFIED_DESC' };
+const queryVariables = { facets: ['ARTICLE', 'TRUCK'], sort: 'PUBLISH_DATE_DESC' };
 const allMagazineData = await fetchMagazineData(queryVariables);
 const allArticles = formatArticlesArray(allMagazineData?.items);
 const allFacets = formatFacetsArray(allMagazineData?.facets);
@@ -32,6 +32,9 @@ const getOptions = (list, placeholder) => {
   list.forEach((el) => {
     const option = createElement('option', { props: { value: el } });
     option.innerText = capitalizeWords(el);
+    if (el == 0) {
+      return;
+    }
     if (el.length !== 0) {
       options.push(option);
     }

--- a/blocks/explore-articles/explore-articles.js
+++ b/blocks/explore-articles/explore-articles.js
@@ -3,7 +3,7 @@ import { fetchMagazineData, formatArticlesArray, formatFacetsArray } from '../..
 
 const blockName = 'explore-articles';
 
-const queryVariables = { facets: ['ARTICLE', 'TRUCK'], sort: 'LAST_MODIFIED_DESC' };
+const queryVariables = { limit: 100, facets: ['ARTICLE', 'TRUCK'], sort: 'LAST_MODIFIED_DESC' };
 const allMagazineData = await fetchMagazineData(queryVariables);
 const allArticles = formatArticlesArray(allMagazineData?.items);
 const allFacets = formatFacetsArray(allMagazineData?.facets);

--- a/constants.json
+++ b/constants.json
@@ -107,7 +107,7 @@
     "data": [
       {
         "name": "TENANT",
-        "value": "vg-macktrucks-com"
+        "value": "macktrucks-co-nz"
       },
       {
         "name": "SEARCH_URL_PROD",

--- a/constants.json
+++ b/constants.json
@@ -107,7 +107,7 @@
     "data": [
       {
         "name": "TENANT",
-        "value": "macktrucks-co-nz"
+        "value": "vg-macktrucks-com"
       },
       {
         "name": "SEARCH_URL_PROD",

--- a/constants.json
+++ b/constants.json
@@ -107,7 +107,7 @@
     "data": [
       {
         "name": "TENANT",
-        "value": "macktrucks-co-nz"
+        "value": "macktrucks-com"
       },
       {
         "name": "SEARCH_URL_PROD",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "aem up",
     "dev:ca": "AEM_PAGES_URL=https://main--macktrucks-ca--volvogroup.aem.page/ aem up",
+    "dev:co-nz": "AEM_PAGES_URL=https://main--macktrucks-co-nz--volvogroup.aem.page/ aem up",
     "dev:com-ar": "AEM_PAGES_URL=https://main--macktrucks-com-ar--volvogroup.aem.page/ aem up",
     "dev:com-au": "AEM_PAGES_URL=https://main--macktrucks-com-au--volvogroup.aem.page/ aem up",
     "dev:com-bo": "AEM_PAGES_URL=https://main--macktrucks-com-bo--volvogroup.aem.page/ aem up",

--- a/scripts/search-api.js
+++ b/scripts/search-api.js
@@ -1,12 +1,10 @@
-import { isDevHost, SEARCH_CONFIGS } from './common.js';
+import { SEARCH_CONFIGS } from './common.js';
 
 export const { TENANT, SEARCH_URL_DEV, SEARCH_URL_PROD } = SEARCH_CONFIGS;
-const isProd = !isDevHost();
-const SEARCH_LINK = isProd ? SEARCH_URL_DEV : SEARCH_URL_PROD;
 
 export async function fetchData(queryObj) {
   try {
-    const response = await fetch(SEARCH_LINK, {
+    const response = await fetch(SEARCH_URL_PROD, {
       method: 'POST',
       headers: {
         Accept: 'application/json',

--- a/scripts/search-api.js
+++ b/scripts/search-api.js
@@ -1,6 +1,6 @@
 import { SEARCH_CONFIGS } from './common.js';
 
-export const { TENANT, SEARCH_URL_DEV, SEARCH_URL_PROD } = SEARCH_CONFIGS;
+export const { TENANT, SEARCH_URL_PROD } = SEARCH_CONFIGS;
 
 export async function fetchData(queryObj) {
   try {

--- a/scripts/search-api.js
+++ b/scripts/search-api.js
@@ -2,7 +2,7 @@ import { isDevHost, SEARCH_CONFIGS } from './common.js';
 
 export const { TENANT, SEARCH_URL_DEV, SEARCH_URL_PROD } = SEARCH_CONFIGS;
 const isProd = !isDevHost();
-const SEARCH_LINK = !isProd ? SEARCH_URL_DEV : SEARCH_URL_PROD;
+const SEARCH_LINK = isProd ? SEARCH_URL_DEV : SEARCH_URL_PROD;
 
 export async function fetchData(queryObj) {
   try {

--- a/scripts/services/magazine.service.js
+++ b/scripts/services/magazine.service.js
@@ -8,7 +8,7 @@ import { fetchData, magazineSearchQuery, TENANT } from '../search-api.js';
  * @returns {Promise<Array>} - A promise that resolves to an array of articles and facets.
  */
 export const fetchMagazineData = async ({
-  limit,
+  limit = 100,
   offset = 0,
   q = 'Mack',
   sort = 'BEST_MATCH',
@@ -24,7 +24,7 @@ export const fetchMagazineData = async ({
     language,
     q,
     category,
-    limit: limit ?? null,
+    limit,
     offset,
     facets,
     sort,
@@ -41,11 +41,6 @@ export const fetchMagazineData = async ({
 
     if (!querySuccess) {
       return allArticleData;
-    }
-
-    if (!limit && limit !== 0) {
-      variables.limit = rawData.data.edssearch.count;
-      return fetchMagazineData(variables);
     }
 
     allArticleData = rawData.data.edssearch;


### PR DESCRIPTION
**NOTES:** 

- This fixes the block not being able to get all articles and instead gets 100 as a default. 
- The correct way would be to modify the current one so that it only get 4 but this would take longer and the bug is in production already
- There is already a V2 block to replace this correctly but its not being used yet.

With that in mind I think its best for us to just merge this into main and decide what are the next steps regarding this page

Fix #292

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/magazine/explore-articles
- After: https://292-magazines-nz--vg-macktrucks-com--volvogroup.aem.page/magazine/explore-articles

Other markets:

New Zaeland:

- Before: https://main--macktrucks-co-nz--volvogroup.aem.page/magazine/explore-articles
- After: https://292-magazines-nz--macktrucks-co-nz--volvogroup.aem.page/magazine/explore-articles
