### PR TITLE
Bug: white close button on header in search page at mobile viewport #286

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -128,6 +128,7 @@ a.header__link {
   align-items: center;
   margin: 0;
   cursor: pointer;
+  color: var(--header-color);
 }
 
 .header__close-menu:focus,


### PR DESCRIPTION
NOTE: This is actuall happening in all **non v2-redesign** pages

Fix #286 

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/search
- After: https://286-header-close-btn--vg-macktrucks-com--volvogroup.aem.page/search

Other markets:

Canada:

- Before: https://main--macktrucks-ca--volvogroup.aem.page/search
- After: https://286-header-close-btn--macktrucks-ca--volvogroup.aem.page/search

Mexico has no search page so instead this can be used:

- Before: https://main--macktrucks-com-mx--volvogroup.aem.page/magazine/
- After: https://286-header-close-btn--macktrucks-com-mx--volvogroup.aem.page/magazine/