### PR TITLE
Bug: form link is used as title #305

### DIFF
--- a/blocks/v2-custom-form/v2-custom-form.js
+++ b/blocks/v2-custom-form/v2-custom-form.js
@@ -618,7 +618,7 @@ export default async function decorate(block) {
   const formLink = block.querySelector('a[href$=".json"]');
   const thankYouPage = [...block.querySelectorAll('a')].filter((a) => a.href.includes('thank-you'));
   const formTitleContainer = block.querySelector(':scope > div:first-child > div');
-  const hasFormLink = formLink && formTitleContainer.contains(formLink);
+  const isFormLinkInsideTitleContainer = formLink && formTitleContainer.contains(formLink);
 
   if (formLink) {
     decorateTitles(block);
@@ -629,8 +629,7 @@ export default async function decorate(block) {
     }
     // clean the content block before appending the form
     block.innerText = '';
-    // add again the content text after the block clean only if the 1st child is not the config form link
-    if (formTitleContainer && !hasFormLink) {
+    if (formTitleContainer && !isFormLinkInsideTitleContainer) {
       addTitleText(formTitleContainer, block);
     }
     block.append(form);

--- a/blocks/v2-custom-form/v2-custom-form.js
+++ b/blocks/v2-custom-form/v2-custom-form.js
@@ -618,6 +618,7 @@ export default async function decorate(block) {
   const formLink = block.querySelector('a[href$=".json"]');
   const thankYouPage = [...block.querySelectorAll('a')].filter((a) => a.href.includes('thank-you'));
   const formTitleContainer = block.querySelector(':scope > div:first-child > div');
+  const hasFormLink = formLink && formTitleContainer.contains(formLink);
 
   if (formLink) {
     decorateTitles(block);
@@ -628,8 +629,8 @@ export default async function decorate(block) {
     }
     // clean the content block before appending the form
     block.innerText = '';
-    // add again the content text after the block clean
-    if (formTitleContainer) {
+    // add again the content text after the block clean only if the 1st child is not the config form link
+    if (formTitleContainer && !hasFormLink) {
       addTitleText(formTitleContainer, block);
     }
     block.append(form);


### PR DESCRIPTION
# Bug fix

After fixing an issue to hide the title text after submitting the v2 custom form block, the block is set up to have as 1st row the title text. In the library is not set as this, so to be able to have it, this fix checks if the 1st row in the block has the config json link to add the title dynamically

#

Fix #305 

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/jlledo/form/title-in-block-form
- After: https://305-form-link-is-used-as-title--vg-macktrucks-com--volvogroup.aem.page/drafts/jlledo/form/title-in-block-form

Library:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-custom-form
- After: https://305-form-link-is-used-as-title--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-custom-form
