### PR TITLE
NFR: Language setting needs to be applied to all website - MT #100

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -511,7 +511,9 @@ async function loadEager(doc) {
     await getPlaceholders();
     await loadSection(main.querySelector('.section'), waitForFirstImage);
   } else {
-    document.documentElement.lang = 'en';
+    const meta_i18n = doc.querySelector('meta[name="i18n"]');
+    const meta_locale = doc.querySelector('meta[name="locale"]');
+    document.documentElement.lang = (meta_i18n && meta_i18n.content) || (meta_locale && meta_locale.content.toLowerCase()) || 'en';
     await getPlaceholders();
   }
 }


### PR DESCRIPTION
Fix #100

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/
- After: https://100-html-lang-settings--vg-macktrucks-com--volvogroup.aem.page/

Other markets:

Canada:

- Before: https://main--macktrucks-ca--volvogroup.aem.page/
- After: https://100-html-lang-settings--macktrucks-ca--volvogroup.aem.page/

Mexico:

- Before: https://main--macktrucks-com-mx--volvogroup.aem.page/
- After: https://100-html-lang-settings--macktrucks-com-mx--volvogroup.aem.page/