### PR TITLE
FR: Add Custom Mute/Unmute button  #310

### DIFF
--- a/common/modal/modal-component.js
+++ b/common/modal/modal-component.js
@@ -133,8 +133,7 @@ const createModal = () => {
           newContent,
           'modal-video',
           {
-            autoplay: 'any',
-            muted: true,
+            autoplay: 'autoplay',
             playsinline: true,
             controls: false,
             loop: false,
@@ -160,7 +159,7 @@ const createModal = () => {
           'modal-video',
           {
             autoplay: 'any',
-            muted: true,
+            muted: false,
             playsinline: true,
             controls: false,
             loop: false,


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #310 

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/powertrain-and-suspensions/transmissions/mdrive/
- After: https://310-play-modal-with-sound--vg-macktrucks-com--volvogroup.aem.page/powertrain-and-suspensions/transmissions/mdrive/

Also from the previous PR:

Test URLs:

Before: https://main--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-columns

After: https://310-play-modal-with-sound--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-columns

Before: https://main--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-embed

After: https://310-play-modal-with-sound--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-embed

Before: https://main--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-video

After: https://310-play-modal-with-sound--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-video

Before: https://main--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-icon-cards

After: https://310-play-modal-with-sound--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-icon-cards

Before: https://main--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-testimonial

After: https://310-play-modal-with-sound--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-testimonial