### PR TITLE
CR: Menu (tabs-with-cards, featured-card-double) - permanently visible hyperlinks in card summary/description text #343

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -357,6 +357,7 @@ a.header__link {
   display: none;
 }
 
+
 .header__category-item a:first-of-type:any-link:not(.standalone-link) {
   display: flex;
 }
@@ -1151,6 +1152,11 @@ a.header__link {
     font-size: 14px;
     line-height: 150%;
     letter-spacing: 0.14px;
+  }
+
+  .header__main-link-wrapper--tabs-with-cards .header__category-item p.with-inline-link,
+  .header__main-link-wrapper--tabs-with-cards .header__category-item p.with-inline-link a.inline-link {
+    display: inline;
   }
 
   /* tabs with cards - END */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1870,7 +1870,6 @@ main .section.responsive-title h1 {
 /* Revert mnobile to default: */
 @media (min-width: 1200px) {
   .redesign-v2 .header .black-label {
-    left: auto;
     font-size: var(--black-label-font-size);
     letter-spacing: var(--label-letter-spacing-small);
     margin-left: var(--black-label-margin-left);


### PR DESCRIPTION
Added a couple of links within the text here and there to test functionality. All point to the same home page

Fix #343

Test URLs:
**NO FEATURED truck**
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/shomps/homepage2/
- After: https://343-inline-links--vg-macktrucks-com--volvogroup.aem.page/drafts/shomps/homepage2/

**1 FEATURED truck**
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/shomps/homepage/
- After: https://343-inline-links--vg-macktrucks-com--volvogroup.aem.page/drafts/shomps/homepage/

**2 FEATURED truck**
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/alan/homepage/
- After: https://343-inline-links--vg-macktrucks-com--volvogroup.aem.page/drafts/alan/homepage/