### PR TITLE
FR: Inconsistency in search suggestions - MT #339

### DIFF
--- a/blocks/search/autosuggest.js
+++ b/blocks/search/autosuggest.js
@@ -14,7 +14,6 @@ export function fetchAutosuggest(term, autosuggestEle, rowEle, func) {
       tenant: TENANT,
       term,
       language,
-      sizeSuggestions: 5,
     },
   }).then(({ errors, data }) => {
     if (errors) {

--- a/scripts/search-api.js
+++ b/scripts/search-api.js
@@ -66,11 +66,11 @@ $facets: [EdsFieldEnum], $sort: EdsSortOptionsEnum, $article: ArticleFilter, $ca
 `;
 
 export const autosuggestQuery = () => `
-query edssuggest($term: String!, $tenant: String!, $language: EdsLocaleEnum!, $sizeSuggestions: Int = 8) {
-  edssuggest(term: $term, tenant: $tenant, language: $language, sizeSuggestions: $sizeSuggestions) {
-    terms
+  query EdsWordPhraseSuggest($term: String!, $tenant: String!, $language: EdsLocaleEnum!) {
+    edsWordPhraseSuggest(term: $term, tenant: $tenant, language: $language) {
+      terms
+    }
   }
-}
 `;
 
 export const magazineSearchQuery = () => `


### PR DESCRIPTION
Fix #339 

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/search
- After: https://339-search-suggest--vg-macktrucks-com--volvogroup.aem.page/search

Other markets:

Canada:

- Before: https://main--macktrucks-ca--volvogroup.aem.page/search
- After: https://339-search-suggest--macktrucks-ca--volvogroup.aem.page/search

Mexico (search not available in mexico yet):