### PR TITLE
Bug: (Mack Trucks) marketing consent on the form goes through as "True" regardless of user input #359

### DIFF
--- a/blocks/v2-custom-form/v2-custom-form.js
+++ b/blocks/v2-custom-form/v2-custom-form.js
@@ -136,7 +136,7 @@ function constructPayload(form) {
         payload[fe.name] = fe.value;
       } else if (fe.type === 'checkbox' && fe.checked) {
         payload[fe.name] = payload[fe.name] ? `${payload[fe.name]},${fe.value}` : fe.value;
-      } else if (fe.type !== 'file') {
+      } else if (fe.type !== 'file' && fe.type !== 'checkbox') {
         payload[fe.name] = fe.value;
       }
     }


### PR DESCRIPTION
Fix #359 

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/
- After: https://359-wrong-marketing-consent-flag--vg-macktrucks-com--volvogroup.aem.page/



**Steps**

1. Right click on the form page and select inspect option to open Dev tools
2. Select Network Tab from tabs bar in Dev tools window.
3. Now fill the form and don't select checkbox to not sent consent and submit the form
4. After submission, couple of requests are added in network list. Click on the first request
5. Select the payload tab on the right side and check the data
6. The checkbox name emailConsent wont be there.

If checkbox is clicked the emailConsent will be there in payload. I added an example to see how to find payload from network tab.
![Screenshot 2025-06-16 at 16 59 42](https://github.com/user-attachments/assets/0d5f82e6-183b-480c-a7f7-bd1e6c4a2112)


