### PR TITLE
add conditionally the dropdown arrow if the accordion block is presen…

### DIFF
--- a/blocks/v2-accordion/v2-accordion.js
+++ b/blocks/v2-accordion/v2-accordion.js
@@ -26,6 +26,8 @@ function loaded(element, pointedContent, display) {
 }
 
 export default async function decorate(block) {
+  const section = block.closest('.section');
+  const hasAccordion = section?.classList.contains(`${blockName}-container`);
   const rows = [...block.querySelectorAll(':scope > div')];
   const accordionsPromises = rows.map(async (row) => {
     const accordionHeader = row.querySelector(
@@ -35,8 +37,9 @@ export default async function decorate(block) {
     const accordionContent = row.querySelector(':scope > div:nth-child(2)');
 
     const headerButton = createElement('button', { classes: `${blockName}__button` });
-    const dropdownArrowIcon = createElement('span', { classes: [`${blockName}__icon`, 'icon', 'icon-dropdown-caret'] });
-    headerButton.append(accordionHeader, dropdownArrowIcon);
+    const dropdownArrowIcon = hasAccordion && createElement('span', { classes: [`${blockName}__icon`, 'icon', 'icon-dropdown-caret'] });
+    // If a the accordion container is not present, we will not add the dropdown arrow icon
+    headerButton.append(accordionHeader, hasAccordion ? dropdownArrowIcon : document.createDocumentFragment());
 
     const contentEl = createElement('div', { classes: [`${blockName}__content`, `${blockName}__content-close`] });
 

--- a/blocks/v2-specifications/v2-specifications.js
+++ b/blocks/v2-specifications/v2-specifications.js
@@ -13,7 +13,7 @@ export default async function decorate(block) {
   let accordionWrapper;
 
   const accordionBlock = createElement('div', {
-    classes: ['block', 'v2-accordion', accordionId],
+    classes: ['block', 'v2-accordion', ...(accordionId ? [accordionId] : [])],
     props: { 'data-block-name': 'v2-accordion' },
   });
 


### PR DESCRIPTION
# Fix

To achieve an unfolded accordion, the following setup is needed:
- In the content page, create a section with the v2-specifications block
- **IMPORTANT**: not include in this section a *v2-accordion* block and follow the example in the draft page


#
Fix #241

### Test URLs:
Unfolded version
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/alexis/md/#specs
- After: https://241-specs-block-improvement--vg-macktrucks-com--volvogroup.aem.page/drafts/alexis/md/#specs


Folded version
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/trucks/md-electric/#specs
- After: https://241-specs-block-improvement--vg-macktrucks-com--volvogroup.aem.page/trucks/md-electric/#specs

