### PR TITLE
FR: [V2 Hero Half-height] Enhancements #70

### DIFF
--- a/blocks/v2-hero/v2-hero.css
+++ b/blocks/v2-hero/v2-hero.css
@@ -211,7 +211,7 @@
 
   .v2-hero--half-height .v2-hero__image {
     position: absolute;
-    aspect-ratio: 32/9; /* 1440 / 372 -> the aspect ratio has been doubled to avoid decimals */
+    aspect-ratio: 32/9; /* 16 / 4.5 -> the aspect ratio has been doubled to avoid decimals */
   }
 
   .v2-hero--half-height .v2-hero__content-wrapper,

--- a/blocks/v2-hero/v2-hero.css
+++ b/blocks/v2-hero/v2-hero.css
@@ -185,7 +185,7 @@
   padding: 40px 16px;
 }
 
-.section--gray-background .v2-hero--half-height .v2-hero__content-wrapper {
+.section--light-gray-background .v2-hero--half-height .v2-hero__content-wrapper {
   background-color: var(--c-tertiary-light-cool-gray);
 }
 
@@ -216,6 +216,7 @@
   }
 
   .v2-hero--half-height .v2-hero__content-wrapper,
+  .section--light-gray-background .v2-hero--half-height .v2-hero__content-wrapper,
   .section.text-black .v2-hero--half-height .v2-hero__content-wrapper,
   .section.text-white .v2-hero--half-height .v2-hero__content-wrapper {
     background-color: unset;

--- a/blocks/v2-hero/v2-hero.css
+++ b/blocks/v2-hero/v2-hero.css
@@ -189,6 +189,10 @@
   background-color: var(--c-primary-black);
 }
 
+.section.gray-background .v2-hero--half-height .v2-hero__content-wrapper {
+  background-color: var(--c-tertiary-light-cool-gray);
+}
+
 .v2-hero--half-height .v2-hero__heading {
   font-size: var(--headline-2-font-size);
 }
@@ -208,8 +212,7 @@
 
   .v2-hero--half-height .v2-hero__image {
     position: absolute;
-    top: -50%;
-    height: auto;
+    aspect-ratio: 32/9; /* 1440 / 372 -> the aspect ratio has been doubled to avoid decimals */
   }
 
   .v2-hero--half-height .v2-hero__content-wrapper,

--- a/blocks/v2-hero/v2-hero.css
+++ b/blocks/v2-hero/v2-hero.css
@@ -156,7 +156,6 @@
 
 /* Half height variant */
 .v2-hero.v2-hero--half-height {
-  max-width: var(--section-max-width);
   margin: 0 auto;
   height: unset;
 }

--- a/blocks/v2-hero/v2-hero.css
+++ b/blocks/v2-hero/v2-hero.css
@@ -185,12 +185,12 @@
   padding: 40px 16px;
 }
 
-.section.text-white .v2-hero--half-height .v2-hero__content-wrapper {
-  background-color: var(--c-primary-black);
+.section--gray-background .v2-hero--half-height .v2-hero__content-wrapper {
+  background-color: var(--c-tertiary-light-cool-gray);
 }
 
-.section.gray-background .v2-hero--half-height .v2-hero__content-wrapper {
-  background-color: var(--c-tertiary-light-cool-gray);
+.section.text-white .v2-hero--half-height .v2-hero__content-wrapper {
+  background-color: var(--c-primary-black);
 }
 
 .v2-hero--half-height .v2-hero__heading {


### PR DESCRIPTION
# Update

new background color -> in section metadata, as a _style_ add a regular _gray background_ key word as usual

## Fixed

added half of an aspect ratio from 16 / 9 to 32 / 9 In the desktop viewport ( > 1200px)

#
Fix #70

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/shomps/v2-hero-half-height
- After: https://70-new-hero-half-height--vg-macktrucks-com--volvogroup.aem.page/drafts/shomps/v2-hero-half-height
