### PR TITLE
FR: Enable Multiple Block [v2 Specifications] per Page #54

### DIFF
--- a/blocks/v2-accordion/v2-accordion.js
+++ b/blocks/v2-accordion/v2-accordion.js
@@ -53,7 +53,7 @@ export default async function decorate(block) {
     contentEl.innerHTML = accordionContent.innerHTML;
 
     if (isContentInsideAnotherElement(accordionContent)) {
-      const pointedContent = document.querySelector(`.${accordionContent.textContent.substring(1)}`);
+      const pointedContent = [...document.querySelectorAll(`.${accordionContent.textContent.substring(1)}`)].at(-1);
       if (pointedContent) {
         const prevDisplay = pointedContent.parentElement.style.display;
         pointedContent.parentElement.style.display = 'none';

--- a/blocks/v2-specifications/v2-specifications.js
+++ b/blocks/v2-specifications/v2-specifications.js
@@ -24,23 +24,19 @@ export default async function decorate(block) {
   block.appendChild(accordionBlockWrapper);
 
   // Hx tag used for the titles of the accordion
-  const titleMeta = block.closest('.section').dataset.header;
-  if (!titleMeta) {
-    return;
-  }
-
+  const titleMeta = block.closest('.section').dataset.header || 'header 3';
   const headerTag = titleMeta.charAt(titleMeta.length - 1);
   const headings = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].slice(headerTag);
+
+  // Add title styles to the headings that are not as the accordion button
+  const headingString = headings.join(',');
+  const headingsList = [...block.querySelectorAll(headingString)];
+  headingsList.forEach((heading) => heading.classList.add(`${blockName}__subtitle`, 'h5'));
 
   [...items].forEach((item) => {
     const typeTitle = item.querySelector(`h${headerTag}`); // header of the accordion
     const typePicture = item.querySelector('picture'); // with image
     const typeDownloads = item.querySelector('.button-container a'); // with downloads
-
-    // Add title styles to the headings that are not as the accordion button
-    const headingString = headings.join(',');
-    const headingsList = [...block.querySelectorAll(headingString)];
-    headingsList.forEach((heading) => heading.classList.add(`${blockName}__subtitle`, 'h5'));
     const subtitleCounter = item.querySelectorAll(`.${blockName}__subtitle`).length;
 
     if (typeTitle) {
@@ -98,7 +94,9 @@ export default async function decorate(block) {
       classes.push(`${blockName}__list--with-text`);
     }
 
-    item.classList.add(...classes);
+    if (classes.length > 0) {
+      item.classList.add(...classes);
+    }
 
     if (accordionContent) {
       accordionContent.appendChild(item);


### PR DESCRIPTION
# Fixed

If another v2 Specifications block was added, to add the content decorated by it, the accordion block looked for the 1st element in the document that matches the title id, moving the content to the bottom of the last specs block.

Now, instead of that, look for the last of them to add it correctly.

## Update

Additionally, I moved a check outside the loop in the v2 specs block, and it conditionally adds a class if there is something to add.
I added again a fallback text in case the _header_ section metadata is missing.

#
Fix #54

### Test URLs:

Ticket examples
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/trucks/trucks-specs-ssot
- After: https://54-multiple-specifications--vg-macktrucks-com--volvogroup.aem.page/trucks/trucks-specs-ssot

In separate sections
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/jlledo/v2-specifications-demo
- After: https://54-multiple-specifications--vg-macktrucks-com--volvogroup.aem.page/drafts/jlledo/v2-specifications-demo

Unfolded example
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/alexis/md/#specs
- After: https://54-multiple-specifications--vg-macktrucks-com--volvogroup.aem.page/drafts/alexis/md/#specs

Regular accordion
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/trucks/md-electric/#specs
- After: https://54-multiple-specifications--vg-macktrucks-com--volvogroup.aem.page/trucks/md-electric/#specs

