### PR TITLE
FR: Update custom header component #219

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -421,6 +421,21 @@ a.header__link {
     justify-content: space-between;
   }
 
+  .header__actions {
+    width: auto;
+  }
+
+  .header__nav-logo--left .header__logo-image-wrapper {
+    position: relative;
+    left: unset;
+    transform: none;
+  }
+
+  .header__nav-logo--left .header__actions,
+  .header__custom .header__nav-logo--left .header__actions {
+    margin-left: 0;
+  }
+
   .header__logo-image-wrapper:has(.icon-bulldog):hover svg {
     opacity: 0;
     transition-delay: 0s;
@@ -442,10 +457,6 @@ a.header__link {
   .header__logo-image-wrapper:has(.icon-bulldog):hover::after {
     opacity: 1;
     transition-delay: calc(var(--duration-small) * 1.25);
-  }
-
-  .header__actions {
-    width: auto;
   }
 
   .header__action-link.header__hamburger-menu {

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -704,7 +704,11 @@ export default async function decorate(block) {
   const content = document.createRange().createContextualFragment(await resp.text());
 
   const [logoContainer, navigationContainer, actionsContainer, ...menuContent] = content.children;
+  const headerLogoAlignment = getMetadata('header-logo-alignment');
   const nav = createElement('nav', { classes: [`${blockName}__nav`] });
+  if (headerLogoAlignment) {
+    nav.classList.add(`${blockName}__nav-logo--${headerLogoAlignment}`);
+  }
   const navContent = document.createRange().createContextualFragment(`
     <div class="${blockName}__menu-overlay"></div>
     ${createLogo(logoContainer).outerHTML}


### PR DESCRIPTION
Fix #219

Note: the left alignment applies only on desktop.

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/alan/nav-logo-left
- After: https://219-header-update--vg-macktrucks-com--volvogroup.aem.page/drafts/alan/nav-logo-left

- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/alan/nav-logo-left-no-button
- After: https://219-header-update--vg-macktrucks-com--volvogroup.aem.page/drafts/alan/nav-logo-left-no-button

Added a note explaining how to place the logo to the left:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/header-and-navigation
- After: https://219-header-update--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/header-and-navigation