### PR TITLE
FR: Enable full-width layout for the V2 Pencil Promo block #293

### DIFF
--- a/blocks/v2-pencil-promo/v2-pencil-promo.css
+++ b/blocks/v2-pencil-promo/v2-pencil-promo.css
@@ -19,6 +19,10 @@
   margin: 24px 0;
 }
 
+.v2-pencil-promo--narrow-text .v2-pencil-promo__content {
+  max-width: 512px;
+}
+
 .v2-pencil-promo:hover {
   cursor: pointer;
 }
@@ -28,6 +32,8 @@
 }
 
 .v2-pencil-promo__content a {
+  display: inline-flex;
+  align-items: center;
   color: var(--text-color);
   text-decoration: underline;
   text-decoration-color: var(--c-accent-red);
@@ -75,13 +81,16 @@
 .v2-pencil-promo__pencil-banner .v2-pencil-promo__content {
   padding: 30px 16px;
   width: 100%;
-  max-width: 512px;
 }
 
 .v2-pencil-promo__pencil-banner .v2-pencil-promo__content p {
   display: inline;
   font: var(--headline-4-font-weight) var(--headline-4-font-size) / var(--headline-4-line-height) var(--ff-subheadings-medium);
   letter-spacing: var(--headline-4-letter-spacing);
+}
+
+.v2-pencil-promo__pencil-banner .icon {
+  height: 24px;
 }
 
 .v2-pencil-promo__pencil-banner .icon svg {

--- a/blocks/v2-pencil-promo/v2-pencil-promo.js
+++ b/blocks/v2-pencil-promo/v2-pencil-promo.js
@@ -14,7 +14,7 @@ function addDataAttributes(element, block) {
 export default async function decorate(block) {
   const blockName = 'v2-pencil-promo';
   // variant pencil banner black is default
-  const variantClasses = ['pencil-banner-black', 'pencil-banner-copper', 'promo-banner-gold', 'promo-banner-copper'];
+  const variantClasses = ['pencil-banner-black', 'pencil-banner-copper', 'promo-banner-gold', 'promo-banner-copper', 'narrow-text'];
   const indexVariant = variantClasses.findIndex((variant) => block.classList.contains(variant));
   const currentVariant = (indexVariant >= 0 && variantClasses[indexVariant]) || variantClasses[0];
   const isPencil = currentVariant.includes('pencil');


### PR DESCRIPTION
Fix #293

Added a `narrow-text` variant to limit text width; the default style renders text full-width.

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-pencil-promo
- After: https://293-v2-pencil-promo-width--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-pencil-promo