### PR TITLE
Bug: [v2-trucks-lineup] #65

### DIFF
--- a/blocks/v2-truck-lineup/v2-truck-lineup.js
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.js
@@ -213,9 +213,9 @@ export default async function decorate(block) {
     [...descriptions].forEach((description) => description.classList.add(`${blockName}__description`));
 
     if (!descriptions || descriptions.length === 0) {
-      const buttonLink = tabContent.querySelector('.button-container:has(:not(.button))');
-      if (buttonLink) {
-        buttonLink.className = `${blockName}__description`;
+      const buttonContainer = tabContent.querySelector('.button-container:has(:not(.button))');
+      if (buttonContainer) {
+        buttonContainer.className = `${blockName}__description`;
       }
     }
 

--- a/blocks/v2-truck-lineup/v2-truck-lineup.js
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.js
@@ -212,6 +212,13 @@ export default async function decorate(block) {
     const descriptions = tabContent.querySelectorAll('p:not(.button-container)');
     [...descriptions].forEach((description) => description.classList.add(`${blockName}__description`));
 
+    if (!descriptions || descriptions.length === 0) {
+      const buttonLink = tabContent.querySelector('.button-container:has(:not(.button))');
+      if (buttonLink) {
+        buttonLink.className = `${blockName}__description`;
+      }
+    }
+
     // Wrap text in container
     const textContainer = createElement('div', { classes: `${blockName}__text` });
     const text = tabContent.querySelector('.default-content-wrapper')?.querySelectorAll(':scope > *:not(.button-container)');


### PR DESCRIPTION
# Bugfix

Now it is not needed to add any dirty workaround to the link to make it not a button. For comparison, I left the demo page and the current one that still has the dot in a single link

#
Fix #65 

Test URLs:

With the dot (scroll to the truck line up)
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/
- After: https://65-v2-trucks-lineup--vg-macktrucks-com--volvogroup.aem.page/

without the dot
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/jlledo/lineup-demo
- After: https://65-v2-trucks-lineup--vg-macktrucks-com--volvogroup.aem.page/drafts/jlledo/lineup-demo

