### PR TITLE
FR: V2 Recommendations block with video  #72

### DIFF
--- a/blocks/v2-recommendations/v2-recommendations.css
+++ b/blocks/v2-recommendations/v2-recommendations.css
@@ -52,6 +52,10 @@
   height: 100%;
 }
 
+.v2-recommendations .v2-video__playback-button {
+  --playback-button-size: 48px
+}
+
 .v2-recommendations__article-content {
   background-color: var(--c-primary-white);
   padding: 24px;

--- a/blocks/v2-recommendations/v2-recommendations.css
+++ b/blocks/v2-recommendations/v2-recommendations.css
@@ -39,6 +39,19 @@
   object-position: center;
 }
 
+.v2-recommendations__article-video {
+  position: relative;
+  height: 241px;
+  width: 100%;
+  object-fit: cover;
+  object-position: center;
+}
+
+.v2-recommendations__article-video .video-js {
+  width: 100%;
+  height: 100%;
+}
+
 .v2-recommendations__article-content {
   background-color: var(--c-primary-white);
   padding: 24px;
@@ -94,7 +107,8 @@
     height: 100%;
   }
 
-  .v2-recommendations__article-image {
+  .v2-recommendations__article-image,
+  .v2-recommendations__article-video {
     height: 198px;
   }
 

--- a/blocks/v2-recommendations/v2-recommendations.js
+++ b/blocks/v2-recommendations/v2-recommendations.js
@@ -124,7 +124,6 @@ const buildBlock = (articles, block) => {
   const fragment = document.createDocumentFragment();
 
   articles.forEach((article) => {
-    console.log(article.videoUrl);
     const articleEl = article.videoUrl ? createVideoArticle(article, blockName) : createImageArticle(article, blockName);
 
     fragment.appendChild(articleEl);

--- a/blocks/v2-recommendations/v2-recommendations.js
+++ b/blocks/v2-recommendations/v2-recommendations.js
@@ -1,73 +1,141 @@
 import { unwrapDivs } from '../../scripts/common.js';
 import { getMetadata } from '../../scripts/aem.js';
-import { fetchMagazineData, sortArticlesByDateField, formatArticlesArray } from '../../scripts/services/magazine.service.js';
+import { fetchRecommendedArticles, sortArticlesByDateField, formatRecommendedArticlesArray } from '../../scripts/services/magazine.service.js';
+import { createVideo } from '../../scripts/video-helper.js';
 
 const blockName = 'v2-recommendations';
 
 /**
- * Retrieves up to 3 articles, prioritizing those in the specified category.
- * If fewer than 3 articles are found in the specified category, it will include
- * fallback articles from other categories to reach a total of 3.
+ * Returns up to `limit` articles, prioritizing those matching the target category.
+ * Maintains the order from the original (already sorted) input list.
  *
- * @param {Array<Object>} articles - The list of articles to filter through. Each article
- *                                   is an object with a `category` property.
- * @param {string} category - The target category to filter articles by.
- * @returns {Array<Object>} - A list of up to 3 articles, prioritizing those in
- *                            the specified category.
+ * @param {Array<Object>} articles - Pre-sorted list of articles.
+ * @param {string} targetCategory - Lowercased category to prioritize.
+ * @param {number} limit - Maximum number of articles to return.
+ * @returns {Array<Object>} - Ordered list of articles, with priority given to matching category.
  */
-const getFilteredArticles = (articles, category) => {
-  const categoryArticles = [];
-  const fallbackArticles = [];
+const filterArticlesByCategoryWithFallback = (articles, targetCategory = '', limit = 3) => {
+  const primary = [];
+  const fallback = [];
+
+  const normalize = (val) => val?.toLowerCase?.();
+  const matchesCategory = (cat) => normalize(cat) === targetCategory;
 
   for (const article of articles) {
-    if (article.category === category) {
-      categoryArticles.push(article);
+    const categories = Array.isArray(article.category) ? article.category : [article.category];
+    if (categories.some(matchesCategory)) {
+      primary.push(article);
+    } else {
+      fallback.push(article);
+    }
+
+    if (primary.length + fallback.length >= limit * 2) {
+      break;
     }
   }
 
-  if (categoryArticles.length < 3) {
-    for (const article of articles) {
-      if (article.category !== category) {
-        fallbackArticles.push(article);
-        if (categoryArticles.length + fallbackArticles.length >= 3) {
-          break;
-        }
-      }
-    }
-  }
+  return [...primary, ...fallback].slice(0, limit);
+};
 
-  // Combine category and fallback articles and return up to 3 articles
-  return categoryArticles.concat(fallbackArticles).slice(0, 3);
+/**
+ * Creates an article element containing a video player outside the anchor.
+ *
+ * @param {Object} article - The article data object.
+ * @param {string} article.path - The URL to the article page.
+ * @param {string} article.videoUrl - The video URL.
+ * @param {string} article.category - The article category label.
+ * @param {string} article.title - The article title.
+ * @param {string} blockName - The base CSS class name for styling.
+ * @returns {HTMLElement} The article element containing the video and metadata.
+ */
+const createVideoArticle = (article, blockName) => {
+  const articleEl = document.createElement('article');
+  articleEl.classList.add(`${blockName}__article`);
+
+  articleEl.innerHTML = `
+    <div class="${blockName}__article-media">
+      <div class="video-placeholder"></div>
+    </div>
+    <a href="${article.path}" class="${blockName}__article-link">
+      <div class="${blockName}__article-content">
+        <p class="${blockName}__article-content-category">${article.category}</p>
+        <h4 class="${blockName}__article-content-title">${article.title}</h4>
+      </div>
+    </a>
+  `;
+
+  const placeholder = articleEl.querySelector('.video-placeholder');
+  const videoEl = createVideo(article.videoUrl, `${blockName}__article-video`, {
+    autoplay: true,
+    muted: true,
+    playsinline: true,
+    controls: false,
+    loop: true,
+  });
+  placeholder.replaceWith(videoEl);
+
+  return articleEl;
+};
+
+/**
+ * Creates an article element with an image wrapped inside the anchor.
+ *
+ * @param {Object} article - The article data object.
+ * @param {string} article.path - The URL to the article page.
+ * @param {string} article.image - The image URL.
+ * @param {string} article.category - The article category label.
+ * @param {string} article.title - The article title.
+ * @param {string} blockName - The base CSS class name for styling.
+ * @returns {HTMLElement} The article element containing the image and metadata.
+ */
+const createImageArticle = (article, blockName) => {
+  const articleEl = document.createElement('article');
+  articleEl.classList.add(`${blockName}__article`);
+
+  articleEl.innerHTML = `
+    <a href="${article.path}" class="${blockName}__article-link">
+      <img src="${article.image}" alt="" class="${blockName}__article-image">
+      <div class="${blockName}__article-content">
+        <p class="${blockName}__article-content-category">${article.category}</p>
+        <h4 class="${blockName}__article-content-title">${article.title}</h4>
+      </div>
+    </a>
+  `;
+
+  return articleEl;
 };
 
 /**
  * Builds and appends a block of related articles to a given block element.
- * Each article is rendered inside an article container with an image, category, and title.
  *
- * @param {Array<Object>} articles - An array of article objects to be rendered. Each article
- * should have the following properties:
- *  - path {string}: The URL path to the article.
- *  - image {string}: The URL of the article's image.
- *  - category {string}: The category of the article.
- *  - title {string}: The title of the article.
- * @param {HTMLElement} block - The block element where the articles container will be appended.
+ * Each article is rendered inside a container with either:
+ * - a video displayed outside the anchor (if `videoUrl` is defined)
+ * - or an image inside the anchor (default)
+ *
+ * @param {Array<Object>} articles - An array of article objects to render.
+ *   Each object should have:
+ *     - path {string}: URL of the article
+ *     - image {string}: Image URL (for non-video articles)
+ *     - videoUrl {string} [optional]: Video URL
+ *     - category {string}: Article category
+ *     - title {string}: Article title
+ * @param {HTMLElement} block - The DOM element to append the rendered block to.
  */
 const buildBlock = (articles, block) => {
   const fragment = document.createDocumentFragment();
 
-  articles.forEach((article) => {
-    const articleElement = document.createElement('article');
-    articleElement.classList.add(`${blockName}__article`);
+  articles.forEach((article, i) => {
+    // TEMP: Add hardcoded video URLs for testing purposes
+    if (i === 1) {
+      article.videoUrl = 'https://www.macktrucks.com/trucks/anthem/media_1f836bcb54c043f523c2172ffdf69139c49d698fc.mp4';
+    }
 
-    articleElement.innerHTML = `
-      <a href="${article.path}" class="${blockName}__article-link">
-        <img src="${article.image}" alt="" class="${blockName}__article-image">
-        <div class="${blockName}__article-content">
-          <p class="${blockName}__article-content-category">${article.category}</p>
-          <h4 class="${blockName}__article-content-title">${article.title}</h4>
-        </div>
-      </a>
-    `;
+    if (i === 2) {
+      article.videoUrl =
+        'https://delivery-p107394-e1241111.adobeaemcloud.com/adobe/assets/urn:aaid:aem:283e5f67-2a55-4fae-ba5e-3f57906999cd/play?accept-experimental=1';
+    }
+
+    const articleElement = article.videoUrl ? createVideoArticle(article, blockName) : createImageArticle(article, blockName);
 
     fragment.appendChild(articleElement);
   });
@@ -87,16 +155,16 @@ const buildBlock = (articles, block) => {
  * @returns {void}
  */
 export default async function decorate(block) {
-  const queryVariables = { facets: [], sort: 'PUBLISH_DATE_DESC' };
-  const allMagazineData = await fetchMagazineData(queryVariables);
-  const allArticles = formatArticlesArray(allMagazineData?.items);
-  if (!allArticles.length) {
+  const recommendedData = await fetchRecommendedArticles();
+  const items = recommendedData?.items || [];
+  const formattedArticles = formatRecommendedArticlesArray(items);
+  if (!formattedArticles.length) {
     return;
   }
 
-  const sortedArticles = sortArticlesByDateField(allArticles, 'date');
-  const category = getMetadata('article-category');
-  const filteredArticles = getFilteredArticles(sortedArticles, category);
+  const sortedArticles = sortArticlesByDateField(formattedArticles, 'date');
+  const articleCategory = getMetadata('article-category')?.toLowerCase?.() || '';
+  const filteredArticles = filterArticlesByCategoryWithFallback(sortedArticles, articleCategory);
 
   if (filteredArticles.length) {
     buildBlock(filteredArticles, block);

--- a/blocks/v2-recommendations/v2-recommendations.js
+++ b/blocks/v2-recommendations/v2-recommendations.js
@@ -1,7 +1,7 @@
 import { unwrapDivs, createElement } from '../../scripts/common.js';
 import { getMetadata } from '../../scripts/aem.js';
 import { fetchRecommendedArticles, sortArticlesByDateField, formatRecommendedArticlesArray } from '../../scripts/services/magazine.service.js';
-import { createVideo } from '../../scripts/video-helper.js';
+import { createVideo, isValidVideoUrl } from '../../scripts/video-helper.js';
 
 const blockName = 'v2-recommendations';
 
@@ -124,8 +124,7 @@ const buildBlock = (articles, block) => {
   const fragment = document.createDocumentFragment();
 
   articles.forEach((article) => {
-    const articleEl = article.videoUrl ? createVideoArticle(article, blockName) : createImageArticle(article, blockName);
-
+    const articleEl = isValidVideoUrl(article.videoUrl) ? createVideoArticle(article, blockName) : createImageArticle(article, blockName);
     fragment.appendChild(articleEl);
   });
 

--- a/scripts/search-api.js
+++ b/scripts/search-api.js
@@ -121,7 +121,7 @@ $category: [String], $facets: [EdsFieldEnum], $article: ArticleFilter, $sort: Ed
 }
 `;
 
-export const topicSearchQuery = () => `
+export const recommendationSearchQuery = () => `
   query Edsrecommend($tenant: String!, $language: EdsLocaleEnum!, $limit: Int, $offset: Int, $category: String, $article: ArticleFilter, $sort: EdsSortOptionsEnum, $facets: [EdsFieldEnum]) {
     edsrecommend(tenant: $tenant, language: $language, limit: $limit, offset: $offset, category: $category, article: $article, sort: $sort, facets: $facets) {
       count
@@ -138,9 +138,11 @@ export const topicSearchQuery = () => `
           image
           article {
             author
+            category
             topic
             truck
             readTime
+            videoUrl
           }
         }
       }

--- a/scripts/services/magazine.service.js
+++ b/scripts/services/magazine.service.js
@@ -202,7 +202,7 @@ export const formatRecommendedArticlesArray = (items = []) => {
         lastModified: meta.lastModified || null,
       };
     })
-    .filter((article) => article.title && article.path); // ensure valid entries
+    .filter((article) => article.title && article.path);
 };
 
 /**

--- a/scripts/services/magazine.service.js
+++ b/scripts/services/magazine.service.js
@@ -1,5 +1,5 @@
 import { getOrigin, getLocale, getTextLabel } from '../common.js';
-import { fetchData, magazineSearchQuery, TENANT } from '../search-api.js';
+import { fetchData, magazineSearchQuery, recommendationSearchQuery, TENANT } from '../search-api.js';
 
 /**
  * Fetches all magazine articles from GraphQL endpoint.
@@ -48,6 +48,64 @@ export const fetchMagazineData = async ({
     return allArticleData || null;
   } catch (error) {
     console.error('Error fetching magazine articles:', error);
+    return [];
+  }
+};
+
+/**
+ * Fetches recommended magazine articles using the edsrecommend query.
+ * @async
+ * @param {Object} options - The query configuration options.
+ * @param {number} [options.limit=100] - Maximum number of articles to retrieve.
+ * @param {number} [options.offset=0] - Offset for pagination.
+ * @param {string} [options.sort='PUBLISH_DATE_DESC'] - Sorting order.
+ * @param {string} [options.tenant=TENANT] - Tenant identifier.
+ * @param {string} [options.language=getLocale().split('-')[0].toUpperCase()] - Language locale.
+ * @param {string|null} [options.category=null] - Category to filter by.
+ * @param {Object|null} [options.article=null] - Additional article filters.
+ * @param {Array|null} [options.facets=null] - Additional facet filters.
+ * @returns {Promise<Object|null>} - An object with `items`, `facets`, etc., or `null`.
+ */
+export const fetchRecommendedArticles = async ({
+  limit = 100,
+  offset = 0,
+  sort = 'PUBLISH_DATE_DESC',
+  tenant = TENANT,
+  language = getLocale().split('-')[0].toUpperCase(),
+  category = null,
+  article = null,
+  facets = null,
+} = {}) => {
+  let allArticleData = [];
+
+  const variables = {
+    tenant,
+    language,
+    limit,
+    offset,
+    sort,
+    category,
+    article,
+    facets,
+  };
+
+  try {
+    const rawData = await fetchData({
+      query: recommendationSearchQuery(),
+      variables,
+    });
+
+    const queryResult = rawData?.data?.edsrecommend;
+
+    if (!queryResult) {
+      return allArticleData;
+    }
+
+    allArticleData = queryResult;
+
+    return allArticleData || null;
+  } catch (error) {
+    console.error('Error fetching recommended articles:', error);
     return [];
   }
 };
@@ -108,6 +166,43 @@ export const formatArticlesArray = (arts = []) => {
     }),
   );
   return articleList;
+};
+
+/**
+ * Formats recommended articles from the edsrecommend query response.
+ * @param {Array} items - Raw article items from GraphQL.
+ * @returns {Array} Formatted article objects.
+ */
+export const formatRecommendedArticlesArray = (items = []) => {
+  const defaultAuthor = getTextLabel('defaultAuthor');
+  const defaultReadTime = getTextLabel('defaultReadTime');
+
+  return items
+    .map((item) => {
+      const meta = item.metadata || {};
+      const articleMeta = meta.article || {};
+
+      const image = meta.image || '';
+      const isImageValid = isImageLink(image);
+      const fullImage = isImageValid ? getOrigin() + image : getDefaultImage();
+
+      return {
+        title: meta.title,
+        description: meta.description,
+        path: meta.url,
+        image: fullImage,
+        isDefaultImage: !isImageValid,
+        author: articleMeta.author || defaultAuthor,
+        readingTime: /\d+/.test(articleMeta.readTime) ? articleMeta.readTime : defaultReadTime,
+        topic: articleMeta.topic || null,
+        truck: Array.isArray(articleMeta.truck) ? articleMeta.truck : [],
+        videoUrl: articleMeta.videoUrl || null,
+        category: articleMeta.category || meta.category || null,
+        date: meta.publishDate || null,
+        lastModified: meta.lastModified || null,
+      };
+    })
+    .filter((article) => article.title && article.path); // ensure valid entries
 };
 
 /**

--- a/scripts/video-helper.js
+++ b/scripts/video-helper.js
@@ -279,6 +279,14 @@ export function isVideoLink(link) {
   );
 }
 
+export function isValidVideoUrl(url) {
+  if (typeof url !== 'string' || !url.trim()) {
+    return false;
+  }
+
+  return isLowResolutionVideoUrl(url) || isAEMVideoUrl(url);
+}
+
 export function selectVideoLink(links, preferredType, videoType = videoTypes.both) {
   const linksArray = Array.isArray(links) ? links : [...links];
   const hasConsentForSocialVideos = isSocialAllowed();

--- a/scripts/video-helper.js
+++ b/scripts/video-helper.js
@@ -651,7 +651,6 @@ function createProgressivePlaybackVideo(src, className = '', props = {}, addMute
   if (props.autoplay) {
     requestAnimationFrame(() => {
       const wrapperParent = wrapper.closest('.v2-embed, .v2-video');
-      console.log(wrapperParent, video);
       if (wrapperParent) {
         observeAutoplayWhenVisible({
           target: video,


### PR DESCRIPTION
Fix #72

For testing purposes, a `video-url` property was added to the metadata of the following two pages. These should be removed once testing is complete:
- [AEM assets video](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%7B9C93632D-D65E-4213-93A6-8494758C907C%7D&file=mack-defense-powers-military-with-next-gen-tactical-trucks.docx&action=default&mobileredirect=true).
- [MP4 video](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%7B30FB7A45-B798-4988-A89C-9C25C29D15DC%7D&file=mack-drives-sustainability-with-smarter-greener-trucks.docx&action=default&mobileredirect=true).

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-recommendations
- After: https://72-v2-recs-video--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-recommendations