### PR TITLE
Bug: Issue with km/mi toggle on V2 Dealer Locator block #311

### DIFF
--- a/blocks/v2-dealer-locator/v2-dealer-locator.css
+++ b/blocks/v2-dealer-locator/v2-dealer-locator.css
@@ -2323,13 +2323,19 @@ main .section.v2-dealer-locator-container > div {
 
 .v2-dealer-locator .legend-header .dealer:not(.disabled),
 .v2-dealer-locator .legend-header .uptime-dealer:not(.disabled),
-.v2-dealer-locator .legend-header .electric-dealer:not(.disabled) {
+.v2-dealer-locator .legend-header .electric-dealer:not(.disabled),
+.v2-dealer-locator .legend-header .mobile-dealer:not(.disabled),
+.v2-dealer-locator .legend-header .mobile-uptime-dealer:not(.disabled),
+.v2-dealer-locator .legend-header .mobile-electric-dealer:not(.disabled) {
   opacity: 1;
 }
 
 .v2-dealer-locator .legend-header .dealer.disabled,
 .v2-dealer-locator .legend-header .uptime-dealer.disabled,
-.v2-dealer-locator .legend-header .electric-dealer.disabled {
+.v2-dealer-locator .legend-header .electric-dealer.disabled,
+.v2-dealer-locator .legend-header .mobile-dealer.disabled,
+.v2-dealer-locator .legend-header .mobile-uptime-dealer.disabled,
+.v2-dealer-locator .legend-header .mobile-electric-dealer.disabled {
   opacity: 0.6;
 }
 

--- a/blocks/v2-dealer-locator/v2-dealer-locator.css
+++ b/blocks/v2-dealer-locator/v2-dealer-locator.css
@@ -2321,16 +2321,16 @@ main .section.v2-dealer-locator-container > div {
   }
 }
 
-.v2-dealer-locator .legend-header .dealer:not(.active),
-.v2-dealer-locator .legend-header .uptime-dealer:not(.active),
-.v2-dealer-locator .legend-header .electric-dealer:not(.active) {
+.v2-dealer-locator .legend-header .dealer:not(.disabled),
+.v2-dealer-locator .legend-header .uptime-dealer:not(.disabled),
+.v2-dealer-locator .legend-header .electric-dealer:not(.disabled) {
   opacity: 1;
 }
 
-.v2-dealer-locator .legend-header .dealer.active,
-.v2-dealer-locator .legend-header .uptime-dealer.active,
-.v2-dealer-locator .legend-header .electric-dealer.active {
-  opacity: 0.5;
+.v2-dealer-locator .legend-header .dealer.disabled,
+.v2-dealer-locator .legend-header .uptime-dealer.disabled,
+.v2-dealer-locator .legend-header .electric-dealer.disabled {
+  opacity: 0.6;
 }
 
 .v2-dealer-locator .sidebar-legend .legend-icon {

--- a/blocks/v2-dealer-locator/v2-dealer-locator.css
+++ b/blocks/v2-dealer-locator/v2-dealer-locator.css
@@ -2321,6 +2321,18 @@ main .section.v2-dealer-locator-container > div {
   }
 }
 
+.v2-dealer-locator .legend-header .dealer:not(.active),
+.v2-dealer-locator .legend-header .uptime-dealer:not(.active),
+.v2-dealer-locator .legend-header .electric-dealer:not(.active) {
+  opacity: 1;
+}
+
+.v2-dealer-locator .legend-header .dealer.active,
+.v2-dealer-locator .legend-header .uptime-dealer.active,
+.v2-dealer-locator .legend-header .electric-dealer.active {
+  opacity: 0.5;
+}
+
 .v2-dealer-locator .sidebar-legend .legend-icon {
   margin-top: -3px;
 }

--- a/blocks/v2-dealer-locator/versions/default/sidebar-maps.js
+++ b/blocks/v2-dealer-locator/versions/default/sidebar-maps.js
@@ -290,23 +290,6 @@ $.fn.initGoogleMaps = function () {
   });
 };
 
-// toggle distance units
-const updateToggle = (e) => {
-  e.preventDefault;
-  const button = e.target.closest('.toggle-button')
-  if (!button) return
-  const activeUnit = button.dataset.active;
-  button.dataset.active = activeUnit === 'mi' ? 'km' : 'mi';
-
-  // update global variable
-  $activeUnit = $activeUnit === 'mi' ? 'km' : 'mi';
-
-  const distanceTags = document.querySelectorAll('.nearby-pins .heading .distance-text');
-  distanceTags.forEach((el) => {
-    el.classList.toggle('active');
-  });
-}
-
 $.fn.getTimeZoneId = async function (dealer) {
   var lat = dealer.MAIN_LATITUDE;
   var long = dealer.MAIN_LONGITUDE;
@@ -1916,7 +1899,6 @@ $.fn.filterNearbyPins = function () {
       });
     }
     if (!toggled) {
-      $(this).css('background', '#484a4e');
       tmpPinList2 = filteredArray;
       $.fn.tmpPins(tmpPinList2);
 
@@ -2004,7 +1986,6 @@ $.fn.filterNearbyPins = function () {
       });
     }
     if (!toggled) {
-      $(this).css('background', '#484a4e');
       tmpPinList3 = filteredDealerArray;
       $.fn.tmpPins(tmpPinList3);
       newList.forEach(function (pin) {
@@ -2091,7 +2072,6 @@ $.fn.filterNearbyPins = function () {
       });
     }
     if (!toggled) {
-      $(this).css('background', '#484a4e');
       tmpPinList4 = filteredDealerArray;
       $.fn.tmpPins(tmpPinList4);
 
@@ -3346,6 +3326,23 @@ $(document).on('click', '#print', function (eventObject) {
   setTimeout(function () { newWin.close(); }, 10);
 
 });
+
+// toggle distance units
+const updateToggle = (e) => {
+  e.preventDefault;
+  const button = e.target.closest('.toggle-button')
+  if (!button) return
+  const activeUnit = button.dataset.active;
+  button.dataset.active = activeUnit === 'mi' ? 'km' : 'mi';
+
+  // update global variable
+  $activeUnit = $activeUnit === 'mi' ? 'km' : 'mi';
+
+  const distanceTags = document.querySelectorAll('.nearby-pins .heading .distance-text');
+  distanceTags.forEach((el) => {
+    el.classList.toggle('active');
+  });
+}
 
 [...$distanceToggles].forEach(toggleBtn => {
   toggleBtn.addEventListener("click", (e) => updateToggle(e));

--- a/blocks/v2-dealer-locator/versions/default/sidebar-maps.js
+++ b/blocks/v2-dealer-locator/versions/default/sidebar-maps.js
@@ -290,6 +290,23 @@ $.fn.initGoogleMaps = function () {
   });
 };
 
+// toggle distance units
+const updateToggle = (e) => {
+  e.preventDefault;
+  const button = e.target.closest('.toggle-button')
+  if (!button) return
+  const activeUnit = button.dataset.active;
+  button.dataset.active = activeUnit === 'mi' ? 'km' : 'mi';
+
+  // update global variable
+  $activeUnit = $activeUnit === 'mi' ? 'km' : 'mi';
+
+  const distanceTags = document.querySelectorAll('.nearby-pins .heading .distance-text');
+  distanceTags.forEach((el) => {
+    el.classList.toggle('active');
+  });
+}
+
 $.fn.getTimeZoneId = async function (dealer) {
   var lat = dealer.MAIN_LATITUDE;
   var long = dealer.MAIN_LONGITUDE;
@@ -1919,16 +1936,14 @@ $.fn.filterNearbyPins = function () {
       document.getElementById('filterElectricDealerMobile').style.pointerEvents = 'none';
       document.getElementById('filterDealerMobile').style.pointerEvents = 'none';
 
-      document.getElementById('filterElectricDealer').classList.toggle('active');
-      document.getElementById('filterDealer').classList.toggle('active');
-      document.getElementById('filterElectricDealerMobile').classList.toggle('active');
-      document.getElementById('filterDealerMobile').classList.toggle('active');
+      document.getElementById('filterElectricDealer').classList.toggle('disabled');
+      document.getElementById('filterDealer').classList.toggle('disabled');
+      document.getElementById('filterElectricDealerMobile').classList.toggle('disabled');
+      document.getElementById('filterDealerMobile').classList.toggle('disabled');
 
       document.getElementById('dealer-tag').setAttribute("title", $hoverText);
       document.getElementById('electric-tag').setAttribute("title", $hoverText);
 
-      console.log('1');
-      
     }
     else {
       $(this).css('background', '#000');
@@ -1953,15 +1968,14 @@ $.fn.filterNearbyPins = function () {
       document.getElementById('filterElectricDealerMobile').style.pointerEvents = 'auto';
       document.getElementById('filterDealerMobile').style.pointerEvents = 'auto';
 
-      document.getElementById('filterElectricDealer').classList.toggle('active');
-      document.getElementById('filterDealer').classList.toggle('active');
-      document.getElementById('filterElectricDealerMobile').classList.toggle('active');
-      document.getElementById('filterDealerMobile').classList.toggle('active');
+      document.getElementById('filterElectricDealer').classList.toggle('disabled');
+      document.getElementById('filterDealer').classList.toggle('disabled');
+      document.getElementById('filterElectricDealerMobile').classList.toggle('disabled');
+      document.getElementById('filterDealerMobile').classList.toggle('disabled');
 
       document.getElementById('dealer-tag').removeAttribute("title", $hoverText);
       document.getElementById('electric-tag').removeAttribute("title", $hoverText);
 
-      console.log('2');
     }
     return false;
   });
@@ -2009,15 +2023,14 @@ $.fn.filterNearbyPins = function () {
       document.getElementById('filterDealerMobile').style.pointerEvents = 'none';
       document.getElementById('filterUptimeMobile').style.pointerEvents = 'none';
 
-      document.getElementById('filterDealer').classList.toggle('active');
-      document.getElementById('filterUptime').classList.toggle('active');
-      document.getElementById('filterDealerMobile').classList.toggle('active');
-      document.getElementById('filterUptimeMobile').classList.toggle('active');
+      document.getElementById('filterDealer').classList.toggle('disabled');
+      document.getElementById('filterUptime').classList.toggle('disabled');
+      document.getElementById('filterDealerMobile').classList.toggle('disabled');
+      document.getElementById('filterUptimeMobile').classList.toggle('disabled');
 
       document.getElementById('dealer-tag').setAttribute("title", $hoverText);
       document.getElementById('uptime-tag').setAttribute("title", $hoverText);
 
-      console.log('3');
     }
     else {
       $(this).css('background', '#000');
@@ -2043,15 +2056,14 @@ $.fn.filterNearbyPins = function () {
       document.getElementById('filterDealerMobile').style.pointerEvents = 'auto';
       document.getElementById('filterUptimeMobile').style.pointerEvents = 'auto';
       
-      document.getElementById('filterDealer').classList.toggle('active');
-      document.getElementById('filterUptime').classList.toggle('active');
-      document.getElementById('filterDealerMobile').classList.toggle('active');
-      document.getElementById('filterUptimeMobile').classList.toggle('active');
+      document.getElementById('filterDealer').classList.toggle('disabled');
+      document.getElementById('filterUptime').classList.toggle('disabled');
+      document.getElementById('filterDealerMobile').classList.toggle('disabled');
+      document.getElementById('filterUptimeMobile').classList.toggle('disabled');
 
       document.getElementById('dealer-tag').removeAttribute("title", $hoverText);
       document.getElementById('uptime-tag').removeAttribute("title", $hoverText);
 
-      console.log('4');
     }
     return false;
   });
@@ -2099,15 +2111,14 @@ $.fn.filterNearbyPins = function () {
       document.getElementById('filterElectricDealerMobile').style.pointerEvents = 'none';
       document.getElementById('filterUptimeMobile').style.pointerEvents = 'none';
 
-      document.getElementById('filterElectricDealer').classList.toggle('active');
-      document.getElementById('filterUptime').classList.toggle('active');
-      document.getElementById('filterElectricDealerMobile').classList.toggle('active');
-      document.getElementById('filterUptimeMobile').classList.toggle('active');
+      document.getElementById('filterElectricDealer').classList.toggle('disabled');
+      document.getElementById('filterUptime').classList.toggle('disabled');
+      document.getElementById('filterElectricDealerMobile').classList.toggle('disabled');
+      document.getElementById('filterUptimeMobile').classList.toggle('disabled');
 
       document.getElementById('electric-tag').setAttribute("title", $hoverText);
       document.getElementById('uptime-tag').setAttribute("title", $hoverText);
 
-      console.log('5');
     }
     else {
       $(this).css('background', '#000');
@@ -2133,15 +2144,14 @@ $.fn.filterNearbyPins = function () {
       document.getElementById('filterElectricDealerMobile').style.pointerEvents = 'auto';
       document.getElementById('filterUptimeMobile').style.pointerEvents = 'auto';
             
-      document.getElementById('filterElectricDealer').classList.toggle('active');
-      document.getElementById('filterUptime').classList.toggle('active');
-      document.getElementById('filterElectricDealerMobile').classList.toggle('active');
-      document.getElementById('filterUptimeMobile').classList.toggle('active');
+      document.getElementById('filterElectricDealer').classList.toggle('disabled');
+      document.getElementById('filterUptime').classList.toggle('disabled');
+      document.getElementById('filterElectricDealerMobile').classList.toggle('disabled');
+      document.getElementById('filterUptimeMobile').classList.toggle('disabled');
       
       document.getElementById('electric-tag').removeAttribute("title", $hoverText);
       document.getElementById('uptime-tag').removeAttribute("title", $hoverText);
 
-      console.log('6');
     }
     return false;
   });
@@ -3336,19 +3346,6 @@ $(document).on('click', '#print', function (eventObject) {
   setTimeout(function () { newWin.close(); }, 10);
 
 });
-
-// toggle distance units
-const updateToggle = (e) => {
-  e.preventDefault;
-  const button = e.target.closest('.toggle-button')
-  if (!button) return
-  const activeUnit = button.dataset.active;
-  button.dataset.active = activeUnit === 'mi' ? 'km' : 'mi';
-  const distanceTags = document.querySelectorAll('.nearby-pins .heading .distance-text');
-  distanceTags.forEach((el) => {
-    el.classList.toggle('active');
-  });
-}
 
 [...$distanceToggles].forEach(toggleBtn => {
   toggleBtn.addEventListener("click", (e) => updateToggle(e));

--- a/blocks/v2-dealer-locator/versions/default/sidebar-maps.js
+++ b/blocks/v2-dealer-locator/versions/default/sidebar-maps.js
@@ -1868,6 +1868,7 @@ $.fn.filterNearbyPins = function () {
   $("#filterElectricDealerMobile,#filterDealerMobile,#filterUptimeMobile").css('background', '#000');
   $("#filterUptime,#filterElectricDealer,#filterDealer").removeData("toggled");
   $("#filterElectricDealerMobile,#filterDealerMobile,#filterUptimeMobile").removeData("toggled");
+
   document.getElementById('filterElectricDealer').style.pointerEvents = 'auto';
   document.getElementById('filterDealer').style.pointerEvents = 'auto';
   document.getElementById('filterUptime').style.pointerEvents = 'auto';
@@ -1912,12 +1913,22 @@ $.fn.filterNearbyPins = function () {
           }
         }
       });
+
       document.getElementById('filterElectricDealer').style.pointerEvents = 'none';
       document.getElementById('filterDealer').style.pointerEvents = 'none';
       document.getElementById('filterElectricDealerMobile').style.pointerEvents = 'none';
       document.getElementById('filterDealerMobile').style.pointerEvents = 'none';
+
+      document.getElementById('filterElectricDealer').classList.toggle('active');
+      document.getElementById('filterDealer').classList.toggle('active');
+      document.getElementById('filterElectricDealerMobile').classList.toggle('active');
+      document.getElementById('filterDealerMobile').classList.toggle('active');
+
       document.getElementById('dealer-tag').setAttribute("title", $hoverText);
       document.getElementById('electric-tag').setAttribute("title", $hoverText);
+
+      console.log('1');
+      
     }
     else {
       $(this).css('background', '#000');
@@ -1936,12 +1947,21 @@ $.fn.filterNearbyPins = function () {
           }
         }
       });
+
       document.getElementById('filterElectricDealer').style.pointerEvents = 'auto';
       document.getElementById('filterDealer').style.pointerEvents = 'auto';
       document.getElementById('filterElectricDealerMobile').style.pointerEvents = 'auto';
       document.getElementById('filterDealerMobile').style.pointerEvents = 'auto';
+
+      document.getElementById('filterElectricDealer').classList.toggle('active');
+      document.getElementById('filterDealer').classList.toggle('active');
+      document.getElementById('filterElectricDealerMobile').classList.toggle('active');
+      document.getElementById('filterDealerMobile').classList.toggle('active');
+
       document.getElementById('dealer-tag').removeAttribute("title", $hoverText);
       document.getElementById('electric-tag').removeAttribute("title", $hoverText);
+
+      console.log('2');
     }
     return false;
   });
@@ -1983,12 +2003,21 @@ $.fn.filterNearbyPins = function () {
           }
         }
       });
+
       document.getElementById('filterDealer').style.pointerEvents = 'none';
       document.getElementById('filterUptime').style.pointerEvents = 'none';
       document.getElementById('filterDealerMobile').style.pointerEvents = 'none';
       document.getElementById('filterUptimeMobile').style.pointerEvents = 'none';
+
+      document.getElementById('filterDealer').classList.toggle('active');
+      document.getElementById('filterUptime').classList.toggle('active');
+      document.getElementById('filterDealerMobile').classList.toggle('active');
+      document.getElementById('filterUptimeMobile').classList.toggle('active');
+
       document.getElementById('dealer-tag').setAttribute("title", $hoverText);
       document.getElementById('uptime-tag').setAttribute("title", $hoverText);
+
+      console.log('3');
     }
     else {
       $(this).css('background', '#000');
@@ -2008,16 +2037,25 @@ $.fn.filterNearbyPins = function () {
           }
         }
       });
+
       document.getElementById('filterDealer').style.pointerEvents = 'auto';
       document.getElementById('filterUptime').style.pointerEvents = 'auto';
       document.getElementById('filterDealerMobile').style.pointerEvents = 'auto';
       document.getElementById('filterUptimeMobile').style.pointerEvents = 'auto';
+      
+      document.getElementById('filterDealer').classList.toggle('active');
+      document.getElementById('filterUptime').classList.toggle('active');
+      document.getElementById('filterDealerMobile').classList.toggle('active');
+      document.getElementById('filterUptimeMobile').classList.toggle('active');
+
       document.getElementById('dealer-tag').removeAttribute("title", $hoverText);
       document.getElementById('uptime-tag').removeAttribute("title", $hoverText);
+
+      console.log('4');
     }
     return false;
   });
-
+ 
   $("#filterDealer, #filterDealerMobile ").unbind().bind("click", function (e) {
     e.preventDefault();
     var tmpPinList4 = [];
@@ -2055,12 +2093,21 @@ $.fn.filterNearbyPins = function () {
           }
         }
       });
+
       document.getElementById('filterElectricDealer').style.pointerEvents = 'none';
       document.getElementById('filterUptime').style.pointerEvents = 'none';
       document.getElementById('filterElectricDealerMobile').style.pointerEvents = 'none';
       document.getElementById('filterUptimeMobile').style.pointerEvents = 'none';
+
+      document.getElementById('filterElectricDealer').classList.toggle('active');
+      document.getElementById('filterUptime').classList.toggle('active');
+      document.getElementById('filterElectricDealerMobile').classList.toggle('active');
+      document.getElementById('filterUptimeMobile').classList.toggle('active');
+
       document.getElementById('electric-tag').setAttribute("title", $hoverText);
       document.getElementById('uptime-tag').setAttribute("title", $hoverText);
+
+      console.log('5');
     }
     else {
       $(this).css('background', '#000');
@@ -2080,12 +2127,21 @@ $.fn.filterNearbyPins = function () {
           }
         }
       });
+
       document.getElementById('filterElectricDealer').style.pointerEvents = 'auto';
       document.getElementById('filterUptime').style.pointerEvents = 'auto';
       document.getElementById('filterElectricDealerMobile').style.pointerEvents = 'auto';
       document.getElementById('filterUptimeMobile').style.pointerEvents = 'auto';
+            
+      document.getElementById('filterElectricDealer').classList.toggle('active');
+      document.getElementById('filterUptime').classList.toggle('active');
+      document.getElementById('filterElectricDealerMobile').classList.toggle('active');
+      document.getElementById('filterUptimeMobile').classList.toggle('active');
+      
       document.getElementById('electric-tag').removeAttribute("title", $hoverText);
       document.getElementById('uptime-tag').removeAttribute("title", $hoverText);
+
+      console.log('6');
     }
     return false;
   });
@@ -3284,8 +3340,10 @@ $(document).on('click', '#print', function (eventObject) {
 // toggle distance units
 const updateToggle = (e) => {
   e.preventDefault;
-  const activeUnit = e.target.dataset.active;
-  e.target.dataset.active = activeUnit === 'mi' ? 'km' : 'mi';
+  const button = e.target.closest('.toggle-button')
+  if (!button) return
+  const activeUnit = button.dataset.active;
+  button.dataset.active = activeUnit === 'mi' ? 'km' : 'mi';
   const distanceTags = document.querySelectorAll('.nearby-pins .heading .distance-text');
   distanceTags.forEach((el) => {
     el.classList.toggle('active');

--- a/blocks/v2-dealer-locator/versions/export/sidebar-maps.js
+++ b/blocks/v2-dealer-locator/versions/export/sidebar-maps.js
@@ -1725,7 +1725,6 @@ $.fn.filterNearbyPins = function () {
       });
     }
     if (!toggled) {
-      $(this).css('background', '#484a4e');
       tmpPinList2 = filteredArray;
       $.fn.tmpPins(tmpPinList2);
 
@@ -1743,6 +1742,12 @@ $.fn.filterNearbyPins = function () {
       document.getElementById('filterDealer').style.pointerEvents = 'none';
       document.getElementById('filterElectricDealerMobile').style.pointerEvents = 'none';
       document.getElementById('filterDealerMobile').style.pointerEvents = 'none';
+
+      document.getElementById('filterElectricDealer').classList.toggle('disabled');
+      document.getElementById('filterDealer').classList.toggle('disabled');
+      document.getElementById('filterElectricDealerMobile').classList.toggle('disabled');
+      document.getElementById('filterDealerMobile').classList.toggle('disabled');
+
       document.getElementById('dealer-tag').setAttribute("title", $hoverText);
       document.getElementById('electric-tag').setAttribute("title", $hoverText);
     }
@@ -1767,6 +1772,12 @@ $.fn.filterNearbyPins = function () {
       document.getElementById('filterDealer').style.pointerEvents = 'auto';
       document.getElementById('filterElectricDealerMobile').style.pointerEvents = 'auto';
       document.getElementById('filterDealerMobile').style.pointerEvents = 'auto';
+
+      document.getElementById('filterElectricDealer').classList.toggle('disabled');
+      document.getElementById('filterDealer').classList.toggle('disabled');
+      document.getElementById('filterElectricDealerMobile').classList.toggle('disabled');
+      document.getElementById('filterDealerMobile').classList.toggle('disabled');
+
       document.getElementById('dealer-tag').removeAttribute("title", $hoverText);
       document.getElementById('electric-tag').removeAttribute("title", $hoverText);
     }
@@ -1797,7 +1808,6 @@ $.fn.filterNearbyPins = function () {
       });
     }
     if (!toggled) {
-      $(this).css('background', '#484a4e');
       tmpPinList3 = filteredDealerArray;
       $.fn.tmpPins(tmpPinList3);
       newList.forEach(function (pin) {
@@ -1814,6 +1824,12 @@ $.fn.filterNearbyPins = function () {
       document.getElementById('filterUptime').style.pointerEvents = 'none';
       document.getElementById('filterDealerMobile').style.pointerEvents = 'none';
       document.getElementById('filterUptimeMobile').style.pointerEvents = 'none';
+
+      document.getElementById('filterDealer').classList.toggle('disabled');
+      document.getElementById('filterUptime').classList.toggle('disabled');
+      document.getElementById('filterDealerMobile').classList.toggle('disabled');
+      document.getElementById('filterUptimeMobile').classList.toggle('disabled');
+
       document.getElementById('dealer-tag').setAttribute("title", $hoverText);
       document.getElementById('uptime-tag').setAttribute("title", $hoverText);
     }
@@ -1839,6 +1855,12 @@ $.fn.filterNearbyPins = function () {
       document.getElementById('filterUptime').style.pointerEvents = 'auto';
       document.getElementById('filterDealerMobile').style.pointerEvents = 'auto';
       document.getElementById('filterUptimeMobile').style.pointerEvents = 'auto';
+
+      document.getElementById('filterDealer').classList.toggle('disabled');
+      document.getElementById('filterUptime').classList.toggle('disabled');
+      document.getElementById('filterDealerMobile').classList.toggle('disabled');
+      document.getElementById('filterUptimeMobile').classList.toggle('disabled');
+
       document.getElementById('dealer-tag').removeAttribute("title", $hoverText);
       document.getElementById('uptime-tag').removeAttribute("title", $hoverText);
     }
@@ -1868,7 +1890,6 @@ $.fn.filterNearbyPins = function () {
       });
     }
     if (!toggled) {
-      $(this).css('background', '#484a4e');
       tmpPinList4 = filteredDealerArray;
       $.fn.tmpPins(tmpPinList4);
 
@@ -1886,6 +1907,12 @@ $.fn.filterNearbyPins = function () {
       document.getElementById('filterUptime').style.pointerEvents = 'none';
       document.getElementById('filterElectricDealerMobile').style.pointerEvents = 'none';
       document.getElementById('filterUptimeMobile').style.pointerEvents = 'none';
+
+      document.getElementById('filterElectricDealer').classList.toggle('disabled');
+      document.getElementById('filterUptime').classList.toggle('disabled');
+      document.getElementById('filterElectricDealerMobile').classList.toggle('disabled');
+      document.getElementById('filterUptimeMobile').classList.toggle('disabled');
+
       document.getElementById('electric-tag').setAttribute("title", $hoverText);
       document.getElementById('uptime-tag').setAttribute("title", $hoverText);
     }
@@ -1911,6 +1938,12 @@ $.fn.filterNearbyPins = function () {
       document.getElementById('filterUptime').style.pointerEvents = 'auto';
       document.getElementById('filterElectricDealerMobile').style.pointerEvents = 'auto';
       document.getElementById('filterUptimeMobile').style.pointerEvents = 'auto';
+
+      document.getElementById('filterElectricDealer').classList.toggle('disabled');
+      document.getElementById('filterUptime').classList.toggle('disabled');
+      document.getElementById('filterElectricDealerMobile').classList.toggle('disabled');
+      document.getElementById('filterUptimeMobile').classList.toggle('disabled');
+
       document.getElementById('electric-tag').removeAttribute("title", $hoverText);
       document.getElementById('uptime-tag').removeAttribute("title", $hoverText);
     }
@@ -3119,8 +3152,14 @@ $(document).on('click', '#print', function (eventObject) {
 // toggle distance units
 const updateToggle = (e) => {
   e.preventDefault;
-  const activeUnit = e.target.dataset.active;
-  e.target.dataset.active = activeUnit === 'mi' ? 'km' : 'mi';
+  const button = e.target.closest('.toggle-button')
+  if (!button) return
+  const activeUnit = button.dataset.active;
+  button.dataset.active = activeUnit === 'mi' ? 'km' : 'mi';
+
+  // update global variable
+  $activeUnit = $activeUnit === 'mi' ? 'km' : 'mi';
+
   const distanceTags = document.querySelectorAll('.nearby-pins .heading .distance-text');
   distanceTags.forEach((el) => {
     el.classList.toggle('active');


### PR DESCRIPTION
Also added an opacity layer to the active/disabled filters for clearer interaction.

**NOTE**: export markets dont have these filters since all dealers are listed as "dealers" only not uptime or electric.

Fix #311 

USA (should be miles by default):
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/buy-mack/find-a-dealer/
- After: https://311-dist-toggle--vg-macktrucks-com--volvogroup.aem.page/buy-mack/find-a-dealer/

Canada:
- Before: https://main--macktrucks-ca--volvogroup.aem.page/buy-mack/find-a-dealer/
- After: https://311-dist-toggle--macktrucks-ca--volvogroup.aem.page/buy-mack/find-a-dealer/

Mexico:
- Before: https://main--macktrucks-com-mx--volvogroup.aem.page/buy-mack/find-a-dealer/
- After: https://311-dist-toggle--macktrucks-com-mx--volvogroup.aem.page/buy-mack/find-a-dealer/

### Some exports markets to check:

Australia:
- Before: https://main--macktrucks-com-au--volvogroup.aem.page/buy-mack/find-a-dealer/
- After: https://311-dist-toggle--macktrucks-com-au--volvogroup.aem.page/buy-mack/find-a-dealer/

Bahamas (this one should default to miles):
- Before: https://main--macktrucks-bs--volvogroup.aem.page/buy-mack/find-a-dealer/
- After: https://311-dist-toggle--macktrucks-bs--volvogroup.aem.page/buy-mack/find-a-dealer/

Chile:
- Before: https://main--macktrucks-cl--volvogroup.aem.page/buy-mack/find-a-dealer/
- After: https://311-dist-toggle--macktrucks-cl--volvogroup.aem.page/buy-mack/find-a-dealer/




