### PR TITLE
Release 48

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "macktrucks",
-  "version": "49.0.0",
+  "version": "48.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "macktrucks",
-      "version": "49.0.0",
+      "version": "48.0.0",
       "license": "UNLICENSED",
       "devDependencies": {
         "@babel/core": "7.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "macktrucks",
   "private": true,
-  "version": "49.0.0",
+  "version": "48.0.0",
   "description": "Mack Trucks",
   "engines": {
     "node": ">=v20.15.1 <23",


### PR DESCRIPTION
Updated package-lock.json file as the version was not updated

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/
- After: https://release-48--vg-macktrucks-com--volvogroup.aem.page/

Other markets:

Canada:

- Before: https://main--macktrucks-ca--volvogroup.aem.page/
- After: https://release-48--macktrucks-ca--volvogroup.aem.page/

Mexico:

- Before: https://main--macktrucks-com-mx--volvogroup.aem.page/
- After: https://release-48--macktrucks-com-mx--volvogroup.aem.page/