### PR TITLE
add missing variant for #419

### DIFF
--- a/blocks/v2-cards/v2-cards.js
+++ b/blocks/v2-cards/v2-cards.js
@@ -11,6 +11,7 @@ const variantClasses = [
   '2-cards-row',
   'spaced',
   'with-border',
+  'with-uncropped-image',
 ];
 
 const decoratePicture = (picture) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "macktrucks",
-  "version": "48.0.0",
+  "version": "48.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "macktrucks",
-      "version": "48.0.0",
+      "version": "48.0.1",
       "license": "UNLICENSED",
       "devDependencies": {
         "@babel/core": "7.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "macktrucks",
   "private": true,
-  "version": "48.0.0",
+  "version": "48.0.1",
   "description": "Mack Trucks",
   "engines": {
     "node": ">=v20.15.1 <23",


### PR DESCRIPTION
Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/
- After: https://release-48-hotfix--vg-macktrucks-com--volvogroup.aem.page/

Other markets:

Canada:

- Before: https://main--macktrucks-ca--volvogroup.aem.page/
- After: https://release-48-hotfix--macktrucks-ca--volvogroup.aem.page/

Mexico:

- Before: https://main--macktrucks-com-mx--volvogroup.aem.page/
- After: https://release-48-hotfix--macktrucks-com-mx--volvogroup.aem.page/

Note: This hotfix is mainly given for issue #419 as some of changes are not moved to main due to conflict merge. 
Test page:  https://release-48-hotfix--vg-macktrucks-com--volvogroup.aem.page/drafts/rishav/bulldog-magazine-test
