### PR TITLE
Transport Canada: Add "Transport Canada Issue Date“ [Mack-English] #441

### DIFF
--- a/blocks/vin-number/vin-number.js
+++ b/blocks/vin-number/vin-number.js
@@ -25,7 +25,6 @@ const valueDisplayList = [
   },
   {
     key: 'tc_recall_date',
-    frenchKey: 'tc_recall_date_french',
   },
   {
     key: 'mfr_recall_number',

--- a/blocks/vin-number/vin-number.js
+++ b/blocks/vin-number/vin-number.js
@@ -24,6 +24,10 @@ const valueDisplayList = [
     key: 'recall_date',
   },
   {
+    key: 'tc_recall_date',
+    frenchKey: 'tc_recall_date_french',
+  },
+  {
     key: 'mfr_recall_number',
   },
   {

--- a/placeholder.json
+++ b/placeholder.json
@@ -140,6 +140,10 @@
       "Text": "Issue Date"
     },
     {
+      "Key": "tc_recall_date",
+      "Text": "Transport Canada Issue Date"
+    },
+    {
       "Key": "recall_description",
       "Text": "Description"
     },


### PR DESCRIPTION
Fix #441

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/recalls/
- After: https://441-vin-issue-date--vg-macktrucks-com--volvogroup.aem.page/recalls/

Tested locally with vin 1M2AN9GY0PM001220

<img width="1125" height="674" alt="Screenshot 2025-09-18 at 11 14 18" src="https://github.com/user-attachments/assets/d9d4d2af-2626-49ec-a2df-489c972621d3" />