### PR TITLE
Transport Canada: Enable date display for "Information last updated" on MT CA Recalls Eng and Fr pages #446

### DIFF
--- a/blocks/vin-number/vin-number.js
+++ b/blocks/vin-number/vin-number.js
@@ -119,15 +119,18 @@ function setStorageItem(key, value) {
 }
 
 async function fetchRefreshDate() {
-  const { url, key } = getAPIConfig();
-  try {
-    const response = await getJsonFromUrl(`${url}refreshdate?api_key=${key}`);
-    setStorageItem('refreshDate-MT', response.refresh_date);
-    return response.refresh_date;
-  } catch (error) {
-    console.error('Error fetching refresh date:', error);
+  const refreshDate = getStorageItem('refreshDate');
+  if (!refreshDate) {
+    const { url, key } = getAPIConfig();
+    try {
+      const response = await getJsonFromUrl(`${url}refreshdate?api_key=${key}`);
+      setStorageItem('refreshDate', response.refresh_date);
+      return response.refresh_date;
+    } catch (error) {
+      console.error('Error fetching refresh date:', error);
+    }
   }
-  return null;
+  return refreshDate;
 }
 
 function renderRecalls(recallsData) {


### PR DESCRIPTION
NOTE: the `/recalls-fr/` page seems unnecessary since it has mixed wording and we already have 2 other pages linked with correct languages

Fix #446 

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/recalls/
- After: https://446-date-display--vg-macktrucks-com--volvogroup.aem.page/recalls/

Other markets:

Canada:

FRENCH
- Before: https://main--macktrucks-ca--volvogroup.aem.page/fr-ca/recalls/
- After: https://446-date-display--macktrucks-ca--volvogroup.aem.page/fr-ca/recalls/

ENGLISH
- Before: https://main--macktrucks-ca--volvogroup.aem.page/recalls/
- After: https://446-date-display--macktrucks-ca--volvogroup.aem.page/recalls/

