### PR TITLE
Bug: VIN number block pointing to wrong URL #462

### DIFF
--- a/blocks/vin-number/vin-number.js
+++ b/blocks/vin-number/vin-number.js
@@ -80,7 +80,7 @@ const recallStatus = {
 function getAPIConfig() {
   let env = 'prod';
 
-  if (window.location.host.includes('hlx.page')) {
+  if (window.location.host.includes('aem.page')) {
     env = 'qa';
   } else if (window.location.host.includes('localhost')) {
     env = 'dev';


### PR DESCRIPTION
Fix #462

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/recalls/
- After: https://462-bug-vin-2--vg-macktrucks-com--volvogroup.aem.page/recalls/

Other markets:

Canada:

- Before: https://main--macktrucks-ca--volvogroup.aem.page/recalls/
- After: https://462-bug-vin-2--macktrucks-ca--volvogroup.aem.page/recalls/
