### PR TITLE
CR: Remove the "Call" button from the dealer locator on Desktop and Tablet - MT #442

### DIFF
--- a/blocks/v2-dealer-locator/v2-dealer-locator.css
+++ b/blocks/v2-dealer-locator/v2-dealer-locator.css
@@ -432,12 +432,12 @@ main .section.v2-dealer-locator-container > div {
   -moz-box-pack: justify;
   -ms-flex-pack: justify;
   padding-top: 14px;
-  gap: 10px;
 }
 
-.v2-dealer-locator .nearby-pins article.teaser .teaser-bottom .left,
-.v2-dealer-locator .nearby-pins article.teaser .teaser-bottom .right {
+.v2-dealer-locator .nearby-pins article.teaser .teaser-bottom .left div,
+.v2-dealer-locator .nearby-pins article.teaser .teaser-bottom .right div {
   min-width: 69px;
+  margin-right: 10px;
 }
 
 .v2-dealer-locator .nearby-pins article.teaser .teaser-bottom .left:hover,
@@ -2742,7 +2742,7 @@ footer {
     min-width: 315px;
   }
 
-  .v2-dealer-locator .nearby-pins article.teaser .teaser-bottom .right:nth-of-type(3) {
+  .v2-dealer-locator .nearby-pins article.teaser .teaser-bottom .right .call {
     display: none;
   }
 }


### PR DESCRIPTION
Fix #442 

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/buy-mack/find-a-dealer/
- After: https://442-dl-call-btn--vg-macktrucks-com--volvogroup.aem.page/buy-mack/find-a-dealer/

Other markets:

Canada:

- Before: https://main--macktrucks-ca--volvogroup.aem.page/buy-mack/find-a-dealer/
- After: https://442-dl-call-btn--macktrucks-ca--volvogroup.aem.page/buy-mack/find-a-dealer/

Mexico:

- Before: https://main--macktrucks-com-mx--volvogroup.aem.page/buy-mack/find-a-dealer/
- After: https://442-dl-call-btn--macktrucks-com-mx--volvogroup.aem.page/buy-mack/find-a-dealer/

Chile:

- Before: https://main--macktrucks-cl--volvogroup.aem.page/buy-mack/find-a-dealer/
- After: https://442-dl-call-btn--macktrucks-cl--volvogroup.aem.page/buy-mack/find-a-dealer/