### PR TITLE
FR: Transport Canada - Field date format needs to match NHTSA date format #464

### DIFF
--- a/blocks/vin-number/vin-number.js
+++ b/blocks/vin-number/vin-number.js
@@ -1,7 +1,7 @@
 import { getTextLabel, createElement, getJsonFromUrl } from '../../scripts/common.js';
 
 const docRange = document.createRange();
-const isFrench = window.location.href.indexOf('fr') > -1;
+const isFrench = window.location.href.indexOf('/fr') > -1;
 const blockName = 'vin-number';
 
 const apiConfig = {


### PR DESCRIPTION
Fix #464

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/recalls/
- After: https://464-fr-date-format--vg-macktrucks-com--volvogroup.aem.page/recalls/

Other markets:

Canada - english:
- Before: https://main--macktrucks-ca--volvogroup.aem.page/recalls/
- After: https://464-fr-date-format--macktrucks-ca--volvogroup.aem.page/recalls/

Canada - french:
- Before: https://main--macktrucks-ca--volvogroup.aem.page/fr-ca/recalls/
- After: https://464-fr-date-format--macktrucks-ca--volvogroup.aem.page/fr-ca/recalls/

<img width="1119" height="840" alt="Screenshot 2025-10-13 at 12 05 37 PM" src="https://github.com/user-attachments/assets/dc1d232c-0db1-4323-a275-7528983de1d8" />
<img width="1103" height="846" alt="Screenshot 2025-10-13 at 5 50 31 PM" src="https://github.com/user-attachments/assets/6c19e162-e09f-4c0a-bb73-e1a2d46ef7a7" />
