### PR TITLE
FR: Implement custom extension to show warning for unsupported blocks on redesign pages - MT #492

### DIFF
--- a/common/snackbar/snackbar.css
+++ b/common/snackbar/snackbar.css
@@ -21,7 +21,7 @@
 .snackbar-container {
   position: fixed;
   inset: 0;
-  padding: 64px 16px 16px;
+  padding: 64px 16px 128px;
   display: flex;
   flex-flow: column wrap;
   place-content: var(--snackbar-position, center flex-end);

--- a/scripts/validate-elements.js
+++ b/scripts/validate-elements.js
@@ -103,7 +103,7 @@ const performDomCheck = () => {
   logCombinedViolations(blockViolations, sectionViolations);
 };
 
-const existingElement = document.querySelector('body > helix-sidekick');
+const existingElement = document.querySelector('body > aem-sidekick');
 if (existingElement) {
   performDomCheck();
 } else {
@@ -111,7 +111,7 @@ if (existingElement) {
     mutationsList.forEach((mutation) => {
       if (mutation.type === 'childList') {
         mutation.addedNodes.forEach((node) => {
-          if (node.nodeType === 1 && node.tagName.toLowerCase() === 'helix-sidekick') {
+          if (node.nodeType === 1 && node.tagName.toLowerCase() === 'aem-sidekick') {
             performDomCheck();
             observer.disconnect();
           }


### PR DESCRIPTION

Fix #492 

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/
- After: https://492-fix-block-validator--vg-macktrucks-com--volvogroup.aem.page/
