### PR TITLE
Bug: Transport Canada_French needs to display when French button selected #499

### DIFF
--- a/blocks/vin-number/vin-number.js
+++ b/blocks/vin-number/vin-number.js
@@ -1,4 +1,4 @@
-import { getTextLabel, createElement, getJsonFromUrl, getLanguagePath } from '../../scripts/common.js';
+import { getTextLabel, createElement, getJsonFromUrl, getLanguagePath, getPlaceholders } from '../../scripts/common.js';
 
 const docRange = document.createRange();
 const isFrench = getLanguagePath() === '/fr-ca/';
@@ -273,6 +273,8 @@ async function fetchRecalls(e) {
 }
 
 export default async function decorate(block) {
+  await getPlaceholders();
+
   const refreshDate = getStorageItem('refreshDate-MT') || '';
   const refresDateWrapper = createElement('div', {
     classes: `${blockName}__refresh-date-wrapper`,


### PR DESCRIPTION
### NOTE -> Test with: 1M1AX04Y5FM024487

Fix #499

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/recalls/
- After: https://499-tc-french--vg-macktrucks-com--volvogroup.aem.page/recalls/

Other markets:

Canada english:

- Before: https://main--macktrucks-ca--volvogroup.aem.page/recalls/
- After: https://499-tc-french--macktrucks-ca--volvogroup.aem.page/recalls/

Canada french:

- Before: https://main--macktrucks-ca--volvogroup.aem.page/fr-ca/recalls/
- After: https://499-tc-french--macktrucks-ca--volvogroup.aem.page/fr-ca/recalls/
