### PR TITLE
FR: Full viewport iframe block w/ option to hide header and footer

### DIFF
--- a/blocks/v2-iframe/v2-iframe.css
+++ b/blocks/v2-iframe/v2-iframe.css
@@ -25,8 +25,8 @@ body.v2-iframe-fullscreen main > :not(.v2-iframe-container) {
   background: var(--primary-white);
 }
 
-.v2-iframe-container--fullscreen .v2-iframe-wrapper,
-.v2-iframe-container--fullscreen .v2-iframe {
+.v2-iframe-fullscreen .v2-iframe-container--fullscreen .v2-iframe-wrapper,
+.v2-iframe-fullscreen .v2-iframe-container--fullscreen .v2-iframe {
   width: 100%;
   height: 100%;
   padding: 0;

--- a/blocks/v2-iframe/v2-iframe.js
+++ b/blocks/v2-iframe/v2-iframe.js
@@ -32,8 +32,8 @@ const getMaxWidth = (block) => findClass(block.classList, /^width-[0-9]+px$/)?.r
  * Enables fullscreen mode for the iframe block.
  *
  * Adds:
- *  - `iframe-container--fullscreen` to the block container
- *  - `iframe-fullscreen` to the document body
+ *  - `${blockName}-container--fullscreen` to the block container
+ *  - `${blockName}-fullscreen` to the document body
  *
  * @param {HTMLElement} block
  */
@@ -61,7 +61,6 @@ const createIframe = (src) =>
   });
 
 export default async function decorate(block) {
-  console.log('Decorating iframe block', block);
   variantsClassesToBEM(block.classList, variantClasses, blockName);
 
   const isFullscreen = block.classList.contains(`${blockName}--fullscreen`);


### PR DESCRIPTION
Fix #386

New v2 version derived from the iframe block, refactored and extended with fullscreen support.

Test URLs:
- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-iframe-fullscreen
- After: https://386-iframe-full-screen--vg-macktrucks-com--volvogroup.aem.page/block-library/blocks/v2-iframe-fullscreen

- Before: https://main--vg-macktrucks-com--volvogroup.aem.page/drafts/alan/v2-iframe-fullscreen
- After: https://386-iframe-full-screen--vg-macktrucks-com--volvogroup.aem.page/drafts/alan/v2-iframe-fullscreen